### PR TITLE
feat: add census choropleth

### DIFF
--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,10 +1,11 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import Map from 'react-map-gl/maplibre';
-import { ScatterplotLayer } from '@deck.gl/layers';
+import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers';
 import DeckGL from '@deck.gl/react';
+import { feature } from 'topojson-client';
 import type { Organization } from '../types/organization';
 
 interface OKCMapProps {
@@ -26,8 +27,68 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
     bearing: 0
   });
 
+  const [geoType, setGeoType] = useState<'zip' | 'tract'>('zip');
+  const [statVar, setStatVar] = useState('B01003_001E');
+  const [censusGeo, setCensusGeo] = useState<any>(null);
+  const [statRange, setStatRange] = useState<{ min: number; max: number }>({ min: 0, max: 0 });
+
+  useEffect(() => {
+    async function loadCensus() {
+      try {
+        let geoUrl = '';
+        let objectName = '';
+        let idProp = '';
+        let dataUrl = '';
+        const state = '40';
+        if (geoType === 'zip') {
+          geoUrl = 'https://cdn.jsdelivr.net/npm/us-atlas@3/zips-10m.json';
+          objectName = 'zipcodes';
+          idProp = 'ZCTA5CE10';
+          dataUrl = `https://api.census.gov/data/2022/acs/acs5?get=NAME,${statVar}&for=zip%20code%20tabulation%20area:*&in=state:${state}`;
+        } else {
+          geoUrl = 'https://cdn.jsdelivr.net/npm/us-atlas@3/tracts-10m.json';
+          objectName = 'tracts';
+          idProp = 'GEOID';
+          dataUrl = `https://api.census.gov/data/2022/acs/acs5?get=NAME,${statVar}&for=tract:*&in=state:${state}&in=county:*`;
+        }
+
+        const [topology, data] = await Promise.all([
+          fetch(geoUrl).then(r => r.json()),
+          fetch(dataUrl).then(r => r.json())
+        ]);
+
+        const geojson: any = feature(topology, topology.objects[objectName]);
+        geojson.features = geojson.features.filter((f: any) => f.properties.STATEFP === state);
+
+        const values = new Map<string, number>();
+        const rows: string[][] = data.slice(1);
+        rows.forEach(row => {
+          const geoid = row[row.length - 1];
+          values.set(geoid, Number(row[1]));
+        });
+
+        const nums: number[] = [];
+        geojson.features.forEach((f: any) => {
+          const geoid = f.properties[idProp];
+          const val = values.get(geoid);
+          f.properties.value = val;
+          if (val !== undefined) nums.push(val);
+        });
+
+        const min = Math.min(...nums);
+        const max = Math.max(...nums);
+        setStatRange({ min, max });
+        setCensusGeo(geojson);
+      } catch (err) {
+        console.error('Failed to load census data', err);
+        setCensusGeo(null);
+      }
+    }
+    loadCensus();
+  }, [geoType, statVar]);
+
   const layers = useMemo(() => {
-    const data = organizations.flatMap(org => 
+    const orgData = organizations.flatMap(org =>
       org.locations.map(location => ({
         coordinates: [location.longitude, location.latitude] as [number, number],
         organization: org,
@@ -35,10 +96,30 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
       }))
     );
 
-    return [
+    const layersArr: any[] = [];
+
+    if (censusGeo) {
+      layersArr.push(
+        new GeoJsonLayer({
+          id: 'census-choropleth',
+          data: censusGeo,
+          stroked: false,
+          filled: true,
+          pickable: true,
+          getFillColor: (d: any) => getChoroplethColor(d.properties.value, statRange),
+          getLineColor: [0, 0, 0, 80],
+          getLineWidth: 1,
+          updateTriggers: {
+            getFillColor: [statRange.min, statRange.max]
+          }
+        })
+      );
+    }
+
+    layersArr.push(
       new ScatterplotLayer({
         id: 'organizations',
-        data: data,
+        data: orgData,
         getPosition: (d: any) => d.coordinates,
         getRadius: 200,
         getFillColor: (d: any) => d.color,
@@ -54,8 +135,10 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
           }
         }
       })
-    ];
-  }, [organizations, onOrganizationClick]);
+    );
+
+    return layersArr;
+  }, [organizations, onOrganizationClick, censusGeo, statRange]);
 
   return (
     <div className="w-full h-full relative">
@@ -64,6 +147,10 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
         onViewStateChange={(e: any) => setViewState(e.viewState)}
         controller={true}
         layers={layers}
+        getTooltip={(info) =>
+          info.object && info.object.properties &&
+          `${info.object.properties.NAME || ''} ${info.object.properties.value ?? ''}`
+        }
         style={{width: '100%', height: '100%'}}
       >
         <Map
@@ -71,6 +158,24 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
           style={{width: '100%', height: '100%'}}
         />
       </DeckGL>
+      <div className="absolute top-2 right-2 bg-white p-2 rounded shadow space-y-2 z-10">
+        <select
+          className="border rounded p-1 w-full"
+          value={geoType}
+          onChange={(e) => setGeoType(e.target.value as 'zip' | 'tract')}
+        >
+          <option value="zip">ZIP Code</option>
+          <option value="tract">Census Tract</option>
+        </select>
+        <select
+          className="border rounded p-1 w-full"
+          value={statVar}
+          onChange={(e) => setStatVar(e.target.value)}
+        >
+          <option value="B01003_001E">Total Population</option>
+          <option value="B19013_001E">Median Household Income</option>
+        </select>
+      </div>
     </div>
   );
 }
@@ -88,6 +193,16 @@ function getCategoryColor(category: string): [number, number, number, number] {
     'Community Development': [253, 126, 20, 200],
     'Other': [134, 142, 150, 200]
   };
-  
+
   return colors[category] || colors['Other'];
+}
+
+function getChoroplethColor(value: number | undefined, range: { min: number; max: number }): [number, number, number, number] {
+  if (value === undefined || Number.isNaN(value)) {
+    return [0, 0, 0, 0];
+  }
+  const t = (value - range.min) / (range.max - range.min || 1);
+  const r = Math.floor(255 * t);
+  const g = Math.floor(255 * (1 - t));
+  return [r, g, 150, 180];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-map-gl": "^8.0.4"
+        "react-map-gl": "^8.0.4",
+        "topojson-client": "^3.1.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-map-gl": "^8.0.4"
+    "react-map-gl": "^8.0.4",
+    "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- add selectable Census choropleth overlays on map
- fetch GeoJSON and stats from US Census and color polygons
- include topojson-client dependency

## Testing
- `npm run build` *(fails: Module not found: Can't resolve 'topojson-client')*
- `npm test` *(fails: missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a134fca54c832d9f3a04279b6ba8f7