### PR TITLE
feat: add census choropleth layer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import db from '../lib/db';
 import AddOrganizationForm from '../components/AddOrganizationForm';
 import CircularAddButton from '../components/CircularAddButton';
 import type { Organization } from '../types/organization';
+import type { GeoType } from '../lib/census';
 
 const OKCMap = dynamic(() => import('../components/OKCMap'), {
   ssr: false,
@@ -15,6 +16,8 @@ const OKCMap = dynamic(() => import('../components/OKCMap'), {
 export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
+  const [geoType, setGeoType] = useState<GeoType>('zip');
+  const [censusVar, setCensusVar] = useState('B01003_001E');
 
   const { data, isLoading, error } = db.useQuery({
     organizations: {
@@ -49,6 +52,22 @@ export default function Home() {
           <div>
             <h1 className="text-2xl font-bold text-gray-900">OKC Non-Profit Map</h1>
             <p className="text-gray-600">Discover local organizations making a difference</p>
+            <div className="mt-2 flex gap-2 text-sm">
+              <select
+                className="border rounded px-2 py-1"
+                value={geoType}
+                onChange={(e) => setGeoType(e.target.value as GeoType)}
+              >
+                <option value="zip">ZIP</option>
+                <option value="tract">Tract</option>
+              </select>
+              <input
+                className="border rounded px-2 py-1"
+                value={censusVar}
+                onChange={(e) => setCensusVar(e.target.value)}
+                placeholder="Census var"
+              />
+            </div>
           </div>
           <CircularAddButton onClick={() => setShowAddForm(true)} />
         </div>
@@ -56,9 +75,10 @@ export default function Home() {
 
       <div className="flex">
         <div className="flex-1 h-screen relative">
-          <OKCMap 
+          <OKCMap
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
+            choropleth={{ geoType, variable: censusVar }}
           />
         </div>
 

--- a/lib/census.ts
+++ b/lib/census.ts
@@ -1,0 +1,71 @@
+import type { FeatureCollection, Feature } from 'geojson';
+
+export type GeoType = 'zip' | 'tract';
+
+interface GeoConfig {
+  boundaryUrl: string;
+  boundaryIdProp: string;
+  dataFor: string;
+  dataIn: string;
+  rowToId: (row: string[]) => string;
+}
+
+const GEO_CONFIG: Record<GeoType, GeoConfig> = {
+  zip: {
+    boundaryUrl:
+      'https://raw.githubusercontent.com/OpenDataDE/State-zip-code-GeoJSON/master/ok_oklahoma_zip_codes_geo.min.json',
+    boundaryIdProp: 'ZCTA5CE10',
+    dataFor: 'zip%20code%20tabulation%20area:*',
+    dataIn: 'state:40',
+    rowToId: (row) => row[row.length - 1]
+  },
+  tract: {
+    boundaryUrl:
+      'https://raw.githubusercontent.com/censusreporter/census-shapefiles/master/geojson/2020/tracts/40.json',
+    boundaryIdProp: 'GEOID',
+    dataFor: 'tract:*',
+    dataIn: 'state:40+county:*',
+    rowToId: (row) => row[2] + row[3] + row[4]
+  }
+};
+
+export async function fetchCensusChoropleth({
+  geoType,
+  variable,
+  year = 2022
+}: {
+  geoType: GeoType;
+  variable: string;
+  year?: number;
+}): Promise<FeatureCollection> {
+  const config = GEO_CONFIG[geoType];
+
+  const url = new URL(`https://api.census.gov/data/${year}/acs/acs5`);
+  url.searchParams.set('get', `NAME,${variable}`);
+  url.searchParams.set('for', config.dataFor);
+  if (config.dataIn) url.searchParams.set('in', config.dataIn);
+
+  const [geoResp, dataResp] = await Promise.all([
+    fetch(config.boundaryUrl).then((r) => r.json()),
+    fetch(url.toString()).then((r) => r.json())
+  ]);
+
+  const [_header, ...rows]: [string[], ...string[][]] = dataResp;
+  const valueIdx = 1;
+  const dataMap: Record<string, number> = {};
+  rows.forEach((row) => {
+    const id = config.rowToId(row);
+    const val = Number(row[valueIdx]);
+    dataMap[id] = isNaN(val) ? 0 : val;
+  });
+
+  const features = geoResp.features.map((f: Feature) => {
+    const id = f.properties[config.boundaryIdProp];
+    return {
+      ...f,
+      properties: { ...f.properties, value: dataMap[id] }
+    };
+  });
+
+  return { type: 'FeatureCollection', features };
+}


### PR DESCRIPTION
## Summary
- fetch US Census statistics and join with boundary data for zip codes and tracts
- overlay choropleth GeoJSON layer on map
- add UI controls for geography type and census variable selection

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a134fca54c832d9f3a04279b6ba8f7