### PR TITLE
Add Census choropleth overlay

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ const OKCMap = dynamic(() => import('../components/OKCMap'), {
 export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
+  const [geoType, setGeoType] = useState<'none' | 'zip' | 'county'>('none');
 
   const { data, isLoading, error } = db.useQuery({
     organizations: {
@@ -56,9 +57,22 @@ export default function Home() {
 
       <div className="flex">
         <div className="flex-1 h-screen relative">
-          <OKCMap 
+          <div className="absolute top-4 left-4 z-10 bg-white bg-opacity-90 p-2 rounded shadow">
+            <label className="text-xs font-medium mr-2">Choropleth</label>
+            <select
+              value={geoType}
+              onChange={(e) => setGeoType(e.target.value as 'none' | 'zip' | 'county')}
+              className="border rounded p-1 text-xs"
+            >
+              <option value="none">None</option>
+              <option value="zip">ZIP Code</option>
+              <option value="county">County</option>
+            </select>
+          </div>
+          <OKCMap
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
+            choropleth={geoType === 'none' ? undefined : { geography: geoType, variable: 'B19013_001E' }}
           />
         </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-map-gl": "^8.0.4"
+        "react-map-gl": "^8.0.4",
+        "topojson-client": "^3.1.0",
+        "us-atlas": "^3.0.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -3400,6 +3402,12 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7526,6 +7534,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -7762,6 +7784,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/us-atlas": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/us-atlas/-/us-atlas-3.0.1.tgz",
+      "integrity": "sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==",
+      "license": "ISC"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-map-gl": "^8.0.4"
+    "react-map-gl": "^8.0.4",
+    "topojson-client": "^3.1.0",
+    "us-atlas": "^3.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- add configurable Census choropleth layer using ZIP or county geographies
- expose choropleth controls in map page
- add topojson-client and us-atlas dependencies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `NEXT_PUBLIC_INSTANT_APP_ID=dummy npm run build` *(fails: Failed to fetch `Geist` font)*

------
https://chatgpt.com/codex/tasks/task_e_68a138e0baa0832db53c263287dfec6d