### PR TITLE
feat: add census choropleth overlay

### DIFF
--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,11 +1,13 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import Map from 'react-map-gl/maplibre';
 import { ScatterplotLayer } from '@deck.gl/layers';
+import { GeoJsonLayer } from '@deck.gl/geo-layers';
 import DeckGL from '@deck.gl/react';
 import type { Organization } from '../types/organization';
+import { fetchChoropleth, colorScale, type Geography } from '../lib/census';
 
 interface OKCMapProps {
   organizations: Organization[];
@@ -25,9 +27,26 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
     pitch: 0,
     bearing: 0
   });
+  const [geography, setGeography] = useState<Geography>('zcta');
+  const [variable, setVariable] = useState('B01003_001E');
+  const [censusData, setCensusData] = useState<any>(null);
+
+  useEffect(() => {
+    fetchChoropleth({ variable, geography })
+      .then(setCensusData)
+      .catch((err) => console.error('Census fetch failed', err));
+  }, [variable, geography]);
+
+  const [min, max] = useMemo(() => {
+    if (!censusData) return [0, 1];
+    const values = censusData.features
+      .map((f: any) => f.properties?.value)
+      .filter((v: any) => typeof v === 'number');
+    return [Math.min(...values), Math.max(...values)];
+  }, [censusData]);
 
   const layers = useMemo(() => {
-    const data = organizations.flatMap(org => 
+    const data = organizations.flatMap(org =>
       org.locations.map(location => ({
         coordinates: [location.longitude, location.latitude] as [number, number],
         organization: org,
@@ -35,40 +54,72 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
       }))
     );
 
-    return [
-      new ScatterplotLayer({
-        id: 'organizations',
-        data: data,
-        getPosition: (d: any) => d.coordinates,
-        getRadius: 200,
-        getFillColor: (d: any) => d.color,
-        getLineColor: [0, 0, 0, 100],
-        getLineWidth: 2,
-        radiusScale: 1,
-        radiusMinPixels: 8,
-        radiusMaxPixels: 20,
-        pickable: true,
-        onClick: (info: any) => {
-          if (info.object && onOrganizationClick) {
-            onOrganizationClick(info.object.organization);
-          }
+    const choropleth = censusData
+      ? new GeoJsonLayer({
+          id: 'census-choropleth',
+          data: censusData,
+          pickable: true,
+          stroked: true,
+          filled: true,
+          getFillColor: (f: any) => colorScale(f.properties?.value ?? null, min, max),
+          getLineColor: [255, 255, 255],
+          lineWidthMinPixels: 1
+        })
+      : null;
+
+    const scatter = new ScatterplotLayer({
+      id: 'organizations',
+      data: data,
+      getPosition: (d: any) => d.coordinates,
+      getRadius: 200,
+      getFillColor: (d: any) => d.color,
+      getLineColor: [0, 0, 0, 100],
+      getLineWidth: 2,
+      radiusScale: 1,
+      radiusMinPixels: 8,
+      radiusMaxPixels: 20,
+      pickable: true,
+      onClick: (info: any) => {
+        if (info.object && onOrganizationClick) {
+          onOrganizationClick(info.object.organization);
         }
-      })
-    ];
-  }, [organizations, onOrganizationClick]);
+      }
+    });
+
+    return choropleth ? [choropleth, scatter] : [scatter];
+  }, [organizations, onOrganizationClick, censusData, min, max]);
 
   return (
     <div className="w-full h-full relative">
+      <div className="absolute top-2 left-2 z-10 bg-white p-2 rounded shadow space-y-2 text-sm">
+        <select
+          className="border rounded p-1 w-full"
+          value={variable}
+          onChange={(e) => setVariable(e.target.value)}
+        >
+          <option value="B01003_001E">Population (ACS 2021)</option>
+          <option value="B19013_001E">Median Income (ACS 2021)</option>
+        </select>
+        <select
+          className="border rounded p-1 w-full"
+          value={geography}
+          onChange={(e) => setGeography(e.target.value as Geography)}
+        >
+          <option value="zcta">ZIP Code</option>
+          <option value="tract">Census Tract</option>
+          <option value="county">County</option>
+        </select>
+      </div>
       <DeckGL
         viewState={viewState}
         onViewStateChange={(e: any) => setViewState(e.viewState)}
         controller={true}
         layers={layers}
-        style={{width: '100%', height: '100%'}}
+        style={{ width: '100%', height: '100%' }}
       >
         <Map
           mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
-          style={{width: '100%', height: '100%'}}
+          style={{ width: '100%', height: '100%' }}
         />
       </DeckGL>
     </div>

--- a/lib/census.ts
+++ b/lib/census.ts
@@ -1,0 +1,81 @@
+import type { FeatureCollection, Feature, Polygon, MultiPolygon } from 'geojson';
+
+export type Geography = 'zcta' | 'tract' | 'county';
+
+const TIGER_LAYER_IDS: Record<Geography, number> = {
+  // Layer ids based on TIGERweb/tigerWMS_Current MapServer
+  // https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer
+  // zcta5 layer id 86, census tract layer id 14, county layer id 6
+  zcta: 86,
+  tract: 14,
+  county: 6
+};
+
+const GEO_FOR_MAP: Record<Geography, string> = {
+  zcta: 'zip+code+tabulation+area',
+  tract: 'tract',
+  county: 'county'
+};
+
+const GEO_ID_FIELD: Record<Geography, string> = {
+  zcta: 'GEOID10',
+  tract: 'GEOID',
+  county: 'GEOID'
+};
+
+const STATE_FIPS = '40'; // Oklahoma
+
+export interface ChoroplethOptions {
+  variable: string; // e.g. B01003_001E total population
+  geography: Geography;
+  bbox?: [number, number, number, number]; // [west, south, east, north]
+}
+
+export async function fetchChoropleth({ variable, geography, bbox }: ChoroplethOptions): Promise<FeatureCollection> {
+  // Fetch statistic values from Census Data API
+  const geoFor = GEO_FOR_MAP[geography];
+  const geoParam = `for=${geoFor}:*&in=state:${STATE_FIPS}`;
+  const dataUrl = `https://api.census.gov/data/2021/acs/acs5?get=NAME,${variable}&${geoParam}`;
+  const resp = await fetch(dataUrl);
+  const json = (await resp.json()) as string[][];
+  const headers = json[0];
+  const records = json.slice(1);
+  const valueIdx = headers.indexOf(variable);
+  const geoIdx = headers.findIndex((h: string) => h.includes(geoFor));
+  const values: Record<string, number> = {};
+  records.forEach((row) => {
+    values[row[geoIdx]] = Number(row[valueIdx]);
+  });
+
+  // Fetch geometry from TIGERweb
+  const layer = TIGER_LAYER_IDS[geography];
+  let url = `https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer/${layer}/query` +
+    `?where=STATE='${STATE_FIPS}'&outFields=GEOID,GEOID10&outSR=4326&f=geojson`;
+  if (bbox) {
+    const [minX, minY, maxX, maxY] = bbox;
+    url += `&geometry=${minX},${minY},${maxX},${maxY}&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&inSR=4326`;    
+  }
+  const geoResp = await fetch(url);
+  const geoJson = (await geoResp.json()) as FeatureCollection;
+
+  // attach values
+  geoJson.features.forEach((f: Feature<Polygon | MultiPolygon, Record<string, unknown>>) => {
+    const geoIdField = GEO_ID_FIELD[geography];
+    const id = (f.properties?.[geoIdField] as string) || '';
+    f.properties = {
+      ...f.properties,
+      value: values[id] ?? null
+    };
+  });
+  return geoJson;
+}
+
+export function colorScale(value: number | null, min: number, max: number): [number, number, number, number] {
+  if (value === null || isNaN(value)) {
+    return [200, 200, 200, 80];
+  }
+  const t = (value - min) / (max - min || 1);
+  const r = Math.round(255 * t);
+  const b = Math.round(255 * (1 - t));
+  return [r, 100, b, 180];
+}


### PR DESCRIPTION
## Summary
- overlay Census ACS statistics as choropleth polygons
- add UI controls for variable and geography selection
- fetch Census data and TIGERweb geometry client-side

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from https://fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_68a138e0baa0832db53c263287dfec6d