### PR TITLE
feat: add census choropleth layer

### DIFF
--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,10 +1,11 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
-import Map from 'react-map-gl/maplibre';
-import { ScatterplotLayer } from '@deck.gl/layers';
+import React, { useState, useMemo, useEffect } from 'react';
+import MapComponent from 'react-map-gl/maplibre';
+import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers';
 import DeckGL from '@deck.gl/react';
+import type { FeatureCollection } from 'geojson';
 import type { Organization } from '../types/organization';
 
 interface OKCMapProps {
@@ -26,8 +27,57 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
     bearing: 0
   });
 
-  const layers = useMemo(() => {
-    const data = organizations.flatMap(org => 
+  const [censusVar, setCensusVar] = useState('B01003_001E');
+  const [censusLayer, setCensusLayer] = useState<GeoJsonLayer | null>(null);
+
+  useEffect(() => {
+    async function loadCensus() {
+      const geoRes = await fetch(
+        "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/Tracts_Blocks/MapServer/2/query?where=STATE='40'%20and%20COUNTY='109'&outFields=GEOID&outSR=4326&f=geojson"
+      );
+      const geo: FeatureCollection = await geoRes.json();
+      const res = await fetch(
+        `https://api.census.gov/data/2022/acs/acs5?get=NAME,${censusVar}&for=tract:*&in=state:40+county:109`
+      );
+      const json = await res.json();
+      const headers = json[0];
+      const varIdx = headers.indexOf(censusVar);
+      const tractIdx = headers.indexOf('tract');
+      const stateIdx = headers.indexOf('state');
+      const countyIdx = headers.indexOf('county');
+      const values = new Map<string, number>(
+        json.slice(1).map((row: string[]) => [
+          `${row[stateIdx]}${row[countyIdx]}${row[tractIdx]}`,
+          Number(row[varIdx])
+        ])
+      );
+      const feats = geo.features.map((f: any) => ({
+        ...f,
+        properties: { ...f.properties, value: values.get(f.properties.GEOID) }
+      }));
+      const max = Math.max(...feats.map((f: any) => f.properties.value ?? 0));
+      const layer = new GeoJsonLayer({
+        id: 'census-choropleth',
+        data: feats,
+        pickable: true,
+        stroked: true,
+        filled: true,
+        getFillColor: (d: any) => {
+          const v = d.properties.value;
+          if (!Number.isFinite(v) || max === 0) return [0, 0, 0, 0];
+          const t = v / max;
+          return [3, 78, 162, 50 + t * 205];
+        },
+        getLineColor: [255, 255, 255],
+        lineWidthMinPixels: 1
+      });
+      setCensusLayer(layer);
+    }
+    loadCensus();
+  }, [censusVar]);
+
+  const orgLayer = useMemo(() => {
+    const data = organizations.flatMap(org =>
       org.locations.map(location => ({
         coordinates: [location.longitude, location.latitude] as [number, number],
         organization: org,
@@ -35,26 +85,24 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
       }))
     );
 
-    return [
-      new ScatterplotLayer({
-        id: 'organizations',
-        data: data,
-        getPosition: (d: any) => d.coordinates,
-        getRadius: 200,
-        getFillColor: (d: any) => d.color,
-        getLineColor: [0, 0, 0, 100],
-        getLineWidth: 2,
-        radiusScale: 1,
-        radiusMinPixels: 8,
-        radiusMaxPixels: 20,
-        pickable: true,
-        onClick: (info: any) => {
-          if (info.object && onOrganizationClick) {
-            onOrganizationClick(info.object.organization);
-          }
+    return new ScatterplotLayer({
+      id: 'organizations',
+      data: data,
+      getPosition: (d: any) => d.coordinates,
+      getRadius: 200,
+      getFillColor: (d: any) => d.color,
+      getLineColor: [0, 0, 0, 100],
+      getLineWidth: 2,
+      radiusScale: 1,
+      radiusMinPixels: 8,
+      radiusMaxPixels: 20,
+      pickable: true,
+      onClick: (info: any) => {
+        if (info.object && onOrganizationClick) {
+          onOrganizationClick(info.object.organization);
         }
-      })
-    ];
+      }
+    });
   }, [organizations, onOrganizationClick]);
 
   return (
@@ -63,14 +111,25 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
         viewState={viewState}
         onViewStateChange={(e: any) => setViewState(e.viewState)}
         controller={true}
-        layers={layers}
+        layers={[censusLayer, orgLayer].filter(Boolean)}
         style={{width: '100%', height: '100%'}}
       >
-        <Map
+        <MapComponent
           mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
           style={{width: '100%', height: '100%'}}
         />
       </DeckGL>
+      <div className="absolute top-2 left-2 z-10 bg-white bg-opacity-90 p-2 rounded shadow text-sm">
+        <label className="mr-2">Statistic</label>
+        <select
+          value={censusVar}
+          onChange={e => setCensusVar(e.target.value)}
+          className="border rounded p-1"
+        >
+          <option value="B01003_001E">Population</option>
+          <option value="B19013_001E">Median Income</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,13 +20,16 @@
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-map-gl": "^8.0.4"
+        "react-map-gl": "^8.0.4",
+        "topojson-client": "^3.1.0",
+        "us-atlas": "^3.0.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/topojson-client": "^3.1.5",
         "eslint": "^9.33.0",
         "eslint-config-next": "^15.4.6",
         "tailwindcss": "^4",
@@ -2221,6 +2224,27 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
@@ -3400,6 +3424,12 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7526,6 +7556,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -7762,6 +7806,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/us-atlas": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/us-atlas/-/us-atlas-3.0.1.tgz",
+      "integrity": "sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==",
+      "license": "ISC"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,16 @@
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-map-gl": "^8.0.4"
+    "react-map-gl": "^8.0.4",
+    "topojson-client": "^3.1.0",
+    "us-atlas": "^3.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/topojson-client": "^3.1.5",
     "eslint": "^9.33.0",
     "eslint-config-next": "^15.4.6",
     "tailwindcss": "^4",


### PR DESCRIPTION
## Summary
- overlay US Census statistics on OKC map as a choropleth
- allow choosing population or median income by county
- add topojson and us-atlas dependencies for boundary data
- add @types/topojson-client and rename map import to fix build errors
- restrict choropleth to Oklahoma County and display tract-level statistics
- build tract GEOIDs from state, county, and tract columns so ACS values shade correctly

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a138e0baa0832db53c263287dfec6d