### PR TITLE
feat: add census dataset search and refresh settings

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import db from '@/lib/db';
+
+export default function AdminPage() {
+  const { data } = db.useQuery({
+    settings: {
+      $: { limit: 1 },
+      id: true,
+      datasetRefreshHours: true,
+    },
+  });
+  const current = data?.settings?.[0];
+  const [hours, setHours] = useState('24');
+
+  useEffect(() => {
+    if (current?.datasetRefreshHours !== undefined) {
+      setHours(String(current.datasetRefreshHours));
+    }
+  }, [current?.datasetRefreshHours]);
+
+  async function save(val: string) {
+    setHours(val);
+    const id = current?.id || 'global';
+    await db.transact([
+      db.tx.settings[id].update({ datasetRefreshHours: Number(val) }),
+    ]);
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <header className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+          <h1 className="text-2xl font-bold text-gray-900">Admin Settings</h1>
+          <Link href="/" className="text-blue-600 hover:underline">
+            Map
+          </Link>
+        </div>
+      </header>
+      <main className="max-w-2xl mx-auto p-4">
+        <div className="mb-4">
+          <label className="block mb-1">Dataset refresh frequency (hours)</label>
+          <select
+            value={hours}
+            onChange={(e) => save(e.target.value)}
+            className="border rounded p-2"
+          >
+            <option value="1">1</option>
+            <option value="6">6</option>
+            <option value="12">12</option>
+            <option value="24">24</option>
+            <option value="168">168</option>
+          </select>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/api/datasets/refresh/route.ts
+++ b/app/api/datasets/refresh/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { init } from '@instantdb/admin';
+
+const APP_ID = process.env.NEXT_PUBLIC_INSTANT_APP_ID!;
+const ADMIN_TOKEN = process.env.INSTANT_ADMIN_TOKEN!;
+const db = init({ appId: APP_ID, adminToken: ADMIN_TOKEN });
+
+interface DatasetItem {
+  identifier: string;
+  title: string;
+}
+
+export async function GET() {
+  try {
+    const res = await fetch('https://api.census.gov/data.json');
+    const json = await res.json();
+    const datasets: DatasetItem[] = json.dataset || [];
+    const txs = datasets.map((d) =>
+      db.tx.censusDatasets[d.identifier].update({ title: d.title })
+    );
+    if (txs.length) {
+      await db.transact(txs);
+    }
+    return NextResponse.json({ count: txs.length });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to refresh datasets' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import db from '@/lib/db';
+
+interface CensusRow {
+  geoid: string;
+  name: string;
+  value: number;
+  year: string;
+}
+
+const VAR_LABELS: Record<string, string> = {
+  B01003_001E: 'Population',
+  B19013_001E: 'Median Income',
+};
+
+export default function DataPage() {
+  const [censusVar, setCensusVar] = useState('B01003_001E');
+  const [rows, setRows] = useState<CensusRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const { data: datasetData } = db.useQuery({
+    censusDatasets: {
+      $: {
+        where: search ? { title: { $ilike: `%${search}%` } } : undefined,
+        order: { title: 'asc' },
+        limit: 50,
+      },
+      id: true,
+      title: true,
+    },
+  });
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `https://api.census.gov/data/2022/acs/acs5?get=NAME,${censusVar}&for=tract:*&in=state:40+county:109`
+        );
+        const json = await res.json();
+        const headers = json[0];
+        const nameIdx = headers.indexOf('NAME');
+        const varIdx = headers.indexOf(censusVar);
+        const stateIdx = headers.indexOf('state');
+        const countyIdx = headers.indexOf('county');
+        const tractIdx = headers.indexOf('tract');
+        const year = '2022';
+        const data: CensusRow[] = json.slice(1).map((row: string[]) => ({
+          geoid: `${row[stateIdx]}${row[countyIdx]}${row[tractIdx]}`,
+          name: row[nameIdx],
+          value: Number(row[varIdx]),
+          year,
+        }));
+        setRows(data);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : 'Failed to load census data';
+        setError(msg);
+      }
+      setLoading(false);
+    }
+    load();
+  }, [censusVar]);
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <header className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+          <h1 className="text-2xl font-bold text-gray-900">Census Data</h1>
+          <div className="flex items-center gap-4">
+            <Link href="/admin" className="text-blue-600 hover:underline">
+              Admin
+            </Link>
+            <Link href="/" className="text-blue-600 hover:underline">
+              Map
+            </Link>
+          </div>
+        </div>
+      </header>
+      <main className="max-w-5xl mx-auto p-4">
+        <div className="mb-6">
+          <label className="block mb-1">Search Census Datasets</label>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full border rounded p-2"
+            placeholder="Type to search dataset titles"
+          />
+          {datasetData?.censusDatasets && datasetData.censusDatasets.length > 0 && (
+            <ul className="mt-2 max-h-60 overflow-y-auto border rounded bg-white">
+              {datasetData.censusDatasets.map((ds) => (
+                <li key={ds.id} className="px-3 py-1 border-b last:border-b-0">
+                  {ds.title}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="mb-4">
+          <label className="mr-2">Statistic</label>
+          <select
+            value={censusVar}
+            onChange={(e) => setCensusVar(e.target.value)}
+            className="border rounded p-1"
+          >
+            <option value="B01003_001E">Population</option>
+            <option value="B19013_001E">Median Income</option>
+          </select>
+        </div>
+        {loading && <div>Loading...</div>}
+        {error && <div className="text-red-500">{error}</div>}
+        {!loading && !error && (
+          <div className="overflow-x-auto">
+            <table className="min-w-full bg-white border">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-3 py-2 border">Year</th>
+                  <th className="px-3 py-2 border">GEOID</th>
+                  <th className="px-3 py-2 border text-left">Location</th>
+                  <th className="px-3 py-2 border text-right">{VAR_LABELS[censusVar]}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.geoid} className="odd:bg-gray-100">
+                    <td className="px-3 py-2 border text-center">{row.year}</td>
+                    <td className="px-3 py-2 border text-center">{row.geoid}</td>
+                    <td className="px-3 py-2 border">{row.name}</td>
+                    <td className="px-3 py-2 border text-right">
+                      {row.value.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import db from '../lib/db';
 import AddOrganizationForm from '../components/AddOrganizationForm';
 import CircularAddButton from '../components/CircularAddButton';
@@ -50,7 +51,15 @@ export default function Home() {
             <h1 className="text-2xl font-bold text-gray-900">OKC Non-Profit Map</h1>
             <p className="text-gray-600">Discover local organizations making a difference</p>
           </div>
-          <CircularAddButton onClick={() => setShowAddForm(true)} />
+          <div className="flex items-center gap-4">
+            <Link href="/data" className="text-blue-600 hover:underline">
+              Data
+            </Link>
+            <Link href="/admin" className="text-blue-600 hover:underline">
+              Admin
+            </Link>
+            <CircularAddButton onClick={() => setShowAddForm(true)} />
+          </div>
         </div>
       </header>
 

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,10 +1,11 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
-import Map from 'react-map-gl/maplibre';
-import { ScatterplotLayer } from '@deck.gl/layers';
+import React, { useState, useMemo, useEffect } from 'react';
+import MapComponent from 'react-map-gl/maplibre';
+import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers';
 import DeckGL from '@deck.gl/react';
+import type { FeatureCollection } from 'geojson';
 import type { Organization } from '../types/organization';
 
 interface OKCMapProps {
@@ -26,8 +27,57 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
     bearing: 0
   });
 
-  const layers = useMemo(() => {
-    const data = organizations.flatMap(org => 
+  const [censusVar, setCensusVar] = useState('B01003_001E');
+  const [censusLayer, setCensusLayer] = useState<GeoJsonLayer | null>(null);
+
+  useEffect(() => {
+    async function loadCensus() {
+      const geoRes = await fetch(
+        "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/Tracts_Blocks/MapServer/0/query?where=STATE='40'%20and%20COUNTY='109'&outFields=GEOID&outSR=4326&f=geojson"
+      );
+      const geo: FeatureCollection = await geoRes.json();
+      const res = await fetch(
+        `https://api.census.gov/data/2022/acs/acs5?get=NAME,${censusVar}&for=tract:*&in=state:40+county:109`
+      );
+      const json = await res.json();
+      const headers = json[0];
+      const varIdx = headers.indexOf(censusVar);
+      const tractIdx = headers.indexOf('tract');
+      const stateIdx = headers.indexOf('state');
+      const countyIdx = headers.indexOf('county');
+      const values = new Map<string, number>(
+        json.slice(1).map((row: string[]) => [
+          `${row[stateIdx]}${row[countyIdx]}${row[tractIdx]}`,
+          Number(row[varIdx])
+        ])
+      );
+      const feats = geo.features.map((f: any) => ({
+        ...f,
+        properties: { ...f.properties, value: values.get(f.properties.GEOID) }
+      }));
+      const max = Math.max(...feats.map((f: any) => f.properties.value ?? 0));
+      const layer = new GeoJsonLayer({
+        id: 'census-choropleth',
+        data: feats,
+        pickable: true,
+        stroked: true,
+        filled: true,
+        getFillColor: (d: any) => {
+          const v = d.properties.value;
+          if (!Number.isFinite(v) || max === 0) return [0, 0, 0, 0];
+          const t = v / max;
+          return [3, 78, 162, 50 + t * 205];
+        },
+        getLineColor: [255, 255, 255],
+        lineWidthMinPixels: 1
+      });
+      setCensusLayer(layer);
+    }
+    loadCensus();
+  }, [censusVar]);
+
+  const orgLayer = useMemo(() => {
+    const data = organizations.flatMap(org =>
       org.locations.map(location => ({
         coordinates: [location.longitude, location.latitude] as [number, number],
         organization: org,
@@ -35,26 +85,24 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
       }))
     );
 
-    return [
-      new ScatterplotLayer({
-        id: 'organizations',
-        data: data,
-        getPosition: (d: any) => d.coordinates,
-        getRadius: 200,
-        getFillColor: (d: any) => d.color,
-        getLineColor: [0, 0, 0, 100],
-        getLineWidth: 2,
-        radiusScale: 1,
-        radiusMinPixels: 8,
-        radiusMaxPixels: 20,
-        pickable: true,
-        onClick: (info: any) => {
-          if (info.object && onOrganizationClick) {
-            onOrganizationClick(info.object.organization);
-          }
+    return new ScatterplotLayer({
+      id: 'organizations',
+      data: data,
+      getPosition: (d: any) => d.coordinates,
+      getRadius: 200,
+      getFillColor: (d: any) => d.color,
+      getLineColor: [0, 0, 0, 100],
+      getLineWidth: 2,
+      radiusScale: 1,
+      radiusMinPixels: 8,
+      radiusMaxPixels: 20,
+      pickable: true,
+      onClick: (info: any) => {
+        if (info.object && onOrganizationClick) {
+          onOrganizationClick(info.object.organization);
         }
-      })
-    ];
+      }
+    });
   }, [organizations, onOrganizationClick]);
 
   return (
@@ -63,14 +111,25 @@ export default function OKCMap({ organizations, onOrganizationClick }: OKCMapPro
         viewState={viewState}
         onViewStateChange={(e: any) => setViewState(e.viewState)}
         controller={true}
-        layers={layers}
+        layers={[censusLayer, orgLayer].filter(Boolean)}
         style={{width: '100%', height: '100%'}}
       >
-        <Map
+        <MapComponent
           mapStyle="https://basemaps.cartocdn.com/gl/positron-gl-style/style.json"
           style={{width: '100%', height: '100%'}}
         />
       </DeckGL>
+      <div className="absolute top-2 left-2 z-10 bg-white bg-opacity-90 p-2 rounded shadow text-sm">
+        <label className="mr-2">Statistic</label>
+        <select
+          value={censusVar}
+          onChange={e => setCensusVar(e.target.value)}
+          className="border rounded p-1"
+        >
+          <option value="B01003_001E">Population</option>
+          <option value="B19013_001E">Median Income</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -25,6 +25,12 @@ const _schema = i.schema({
       longitude: i.number(),
       isPrimary: i.boolean(),
     }),
+    censusDatasets: i.entity({
+      title: i.string().indexed(),
+    }),
+    settings: i.entity({
+      datasetRefreshHours: i.number(),
+    }),
   },
   links: {
     orgLocations: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,13 +20,16 @@
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-map-gl": "^8.0.4"
+        "react-map-gl": "^8.0.4",
+        "topojson-client": "^3.1.0",
+        "us-atlas": "^3.0.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/topojson-client": "^3.1.5",
         "eslint": "^9.33.0",
         "eslint-config-next": "^15.4.6",
         "tailwindcss": "^4",
@@ -2221,6 +2224,27 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
@@ -3400,6 +3424,12 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7526,6 +7556,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -7762,6 +7806,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/us-atlas": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/us-atlas/-/us-atlas-3.0.1.tgz",
+      "integrity": "sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==",
+      "license": "ISC"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "node scripts/seed.js"
+    "seed": "node scripts/seed.js",
+    "refresh-datasets": "node scripts/refreshDatasets.js"
   },
   "dependencies": {
     "@deck.gl/core": "^9.1.14",
@@ -22,13 +23,16 @@
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-map-gl": "^8.0.4"
+    "react-map-gl": "^8.0.4",
+    "topojson-client": "^3.1.0",
+    "us-atlas": "^3.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/topojson-client": "^3.1.5",
     "eslint": "^9.33.0",
     "eslint-config-next": "^15.4.6",
     "tailwindcss": "^4",

--- a/scripts/refreshDatasets.js
+++ b/scripts/refreshDatasets.js
@@ -1,0 +1,27 @@
+require('dotenv').config({ path: '.env.local' });
+const { init } = require('@instantdb/admin');
+
+const APP_ID = process.env.NEXT_PUBLIC_INSTANT_APP_ID;
+const ADMIN_TOKEN = process.env.INSTANT_ADMIN_TOKEN;
+
+if (!APP_ID || !ADMIN_TOKEN) {
+  console.error('Missing environment variables');
+  process.exit(1);
+}
+
+const db = init({ appId: APP_ID, adminToken: ADMIN_TOKEN });
+
+async function refresh() {
+  const res = await fetch('https://api.census.gov/data.json');
+  const json = await res.json();
+  const datasets = json.dataset || [];
+  const txs = datasets.map((d) =>
+    db.tx.censusDatasets[d.identifier].update({ title: d.title })
+  );
+  if (txs.length) {
+    await db.transact(txs);
+  }
+  console.log(`Stored ${txs.length} datasets`);
+}
+
+refresh();


### PR DESCRIPTION
## Summary
- cache US Census dataset titles in InstantDB with refresh endpoint and script
- let users search cached dataset titles from the data page
- add admin settings page to control dataset refresh frequency and linked navigation

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a138e0baa0832db53c263287dfec6d