### PR TITLE
feat: add census stat search page

### DIFF
--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { fetchZipStats, type ZipStats } from '../../lib/zipStats';
 
 export default function DataPage() {
@@ -26,16 +27,21 @@ export default function DataPage() {
   return (
     <div className="min-h-screen p-4 bg-gray-100 text-black">
       <h1 className="text-2xl font-bold mb-4 text-black">Oklahoma City ZIP Data</h1>
-      <div className="mb-4">
-        <label className="mr-2">Metric:</label>
-        <select
-          value={metric}
-          onChange={(e) => setMetric(e.target.value as 'population' | 'applications')}
-          className="border px-1 py-0.5"
-        >
-          <option value="population">Population</option>
-          <option value="applications">Business Applications</option>
-        </select>
+      <div className="mb-4 flex items-center gap-4">
+        <div>
+          <label className="mr-2">Metric:</label>
+          <select
+            value={metric}
+            onChange={(e) => setMetric(e.target.value as 'population' | 'applications')}
+            className="border px-1 py-0.5"
+          >
+            <option value="population">Population</option>
+            <option value="applications">Business Applications</option>
+          </select>
+        </div>
+        <Link href="/stats" className="text-blue-600 hover:underline text-sm">
+          Search Census stats
+        </Link>
       </div>
       {loading && <div>Loading...</div>}
       {error && <div className="text-red-500">{error}</div>}

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface Dataset {
+  title: string;
+  variablesLink: string;
+}
+
+interface RawDataset {
+  title?: string;
+  c_variablesLink?: string;
+}
+
+interface Variable {
+  name: string;
+  label: string;
+  concept?: string;
+}
+
+interface RawVariable {
+  label: string;
+  concept?: string;
+}
+
+export default function CensusStatExplorer() {
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [datasetQuery, setDatasetQuery] = useState('');
+  const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null);
+  const [variables, setVariables] = useState<Variable[]>([]);
+  const [varQuery, setVarQuery] = useState('');
+  const [loadingVars, setLoadingVars] = useState(false);
+
+  useEffect(() => {
+    async function loadDatasets() {
+      try {
+        const res = await fetch('https://api.census.gov/data.json');
+        const json = await res.json();
+        const ds: Dataset[] = (json.dataset as RawDataset[] || [])
+          .filter((d) => d.c_variablesLink)
+          .map((d) => ({
+            title: d.title || 'Untitled dataset',
+            variablesLink: d.c_variablesLink as string,
+          }));
+        setDatasets(ds);
+      } catch (err) {
+        console.error('Failed to load datasets', err);
+      }
+    }
+    loadDatasets();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedDataset) return;
+    const link = selectedDataset.variablesLink;
+    async function loadVariables() {
+      setLoadingVars(true);
+      try {
+        const res = await fetch(link);
+        const json = await res.json();
+        const vars: Variable[] = Object.entries(
+          (json.variables as Record<string, RawVariable>) || {}
+        ).map(([name, info]) => ({
+          name,
+          label: info.label,
+          concept: info.concept,
+        }));
+        setVariables(vars);
+      } catch (err) {
+        console.error('Failed to load variables', err);
+      } finally {
+        setLoadingVars(false);
+      }
+    }
+    loadVariables();
+  }, [selectedDataset]);
+
+  const filteredDatasets = datasets.filter((d) =>
+    d.title.toLowerCase().includes(datasetQuery.toLowerCase())
+  );
+
+  const filteredVars = variables.filter((v) =>
+    `${v.name} ${v.label} ${v.concept ?? ''}`
+      .toLowerCase()
+      .includes(varQuery.toLowerCase())
+  );
+
+  return (
+    <div className="min-h-screen p-4 bg-gray-100 text-black">
+      <h1 className="text-2xl font-bold mb-4">Census Stat Explorer</h1>
+
+      {!selectedDataset ? (
+        <div>
+          <input
+            type="text"
+            value={datasetQuery}
+            onChange={(e) => setDatasetQuery(e.target.value)}
+            placeholder="Search datasets..."
+            className="border px-2 py-1 mb-4 w-full max-w-md"
+          />
+          <ul className="space-y-2 max-h-[60vh] overflow-y-auto">
+            {filteredDatasets.map((d) => (
+              <li key={d.variablesLink}>
+                <button
+                  onClick={() => setSelectedDataset(d)}
+                  className="text-blue-600 hover:underline"
+                >
+                  {d.title}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <div>
+          <button
+            onClick={() => {
+              setSelectedDataset(null);
+              setVariables([]);
+              setVarQuery('');
+            }}
+            className="text-blue-600 hover:underline mb-4"
+          >
+            ← Back to datasets
+          </button>
+          <h2 className="text-xl font-semibold mb-2">
+            {selectedDataset.title}
+          </h2>
+          <input
+            type="text"
+            value={varQuery}
+            onChange={(e) => setVarQuery(e.target.value)}
+            placeholder="Search variables..."
+            className="border px-2 py-1 mb-4 w-full max-w-md"
+          />
+          {loadingVars ? (
+            <div>Loading...</div>
+          ) : (
+            <ul className="space-y-2 max-h-[60vh] overflow-y-auto">
+              {filteredVars.map((v) => (
+                <li key={v.name} className="bg-white p-2 rounded shadow">
+                  <div className="font-mono text-sm">{v.name}</div>
+                  <div className="text-sm">{v.label}</div>
+                  {v.concept && (
+                    <div className="text-xs text-gray-500">{v.concept}</div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Census Stat Explorer page to browse dataset variables
- link from ZIP data page to new search interface

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a242c3c494832dbf98117588572db0