### PR TITLE
feat: add census stat search

### DIFF
--- a/app/data/search/page.tsx
+++ b/app/data/search/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { fetchCensusVariables, type CensusVariable } from '../../../lib/census';
+
+export default function SearchCensusStatsPage() {
+  const [vars, setVars] = useState<CensusVariable[]>([]);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchCensusVariables()
+      .then((v) => setVars(v))
+      .catch(() => setError('Failed to load census variables'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = query
+    ? vars.filter(
+        (v) =>
+          v.name.toLowerCase().includes(query.toLowerCase()) ||
+          v.label.toLowerCase().includes(query.toLowerCase()) ||
+          v.concept.toLowerCase().includes(query.toLowerCase())
+      )
+    : [];
+
+  return (
+    <div className="min-h-screen p-4 bg-gray-100 text-black">
+      <h1 className="text-2xl font-bold mb-4">Search Census Stats</h1>
+      <input
+        type="text"
+        placeholder="Search by name or description..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="w-full max-w-xl px-4 py-2 mb-4 border rounded"
+      />
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-500">{error}</div>}
+      {!loading && !error && query && filtered.length === 0 && (
+        <div>No results found.</div>
+      )}
+      {!loading && !error && filtered.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-300 bg-white">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-2 text-left text-sm font-semibold text-black">Name</th>
+                <th className="px-4 py-2 text-left text-sm font-semibold text-black">Label</th>
+                <th className="px-4 py-2 text-left text-sm font-semibold text-black">Concept</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {filtered.map((v) => (
+                <tr key={v.name}>
+                  <td className="px-4 py-2 text-sm text-black">{v.name}</td>
+                  <td className="px-4 py-2 text-sm text-black">{v.label}</td>
+                  <td className="px-4 py-2 text-sm text-black">{v.concept}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,6 +54,7 @@ export default function Home() {
           </div>
           <div className="flex items-center gap-4">
             <Link href="/data" className="text-blue-600 hover:underline">Data</Link>
+            <Link href="/data/search" className="text-blue-600 hover:underline">Search Stats</Link>
             <CircularAddButton onClick={() => setShowAddForm(true)} />
           </div>
         </div>

--- a/lib/census.ts
+++ b/lib/census.ts
@@ -1,0 +1,25 @@
+export interface CensusVariable {
+  name: string;
+  label: string;
+  concept: string;
+}
+
+let cached: CensusVariable[] | null = null;
+
+export async function fetchCensusVariables(): Promise<CensusVariable[]> {
+  if (cached) return cached;
+  const res = await fetch('https://api.census.gov/data/2021/acs/acs5/variables.json');
+  if (!res.ok) {
+    throw new Error('Failed to load census variables');
+  }
+  const json = await res.json();
+  type VariableInfo = { label: string; concept: string };
+  const vars = json.variables as Record<string, VariableInfo>;
+  const variables = Object.entries(vars).map(([name, info]) => ({
+    name,
+    label: info.label,
+    concept: info.concept
+  }));
+  cached = variables;
+  return variables;
+}


### PR DESCRIPTION
## Summary
- add client-side search page for US Census variables
- expose new search tool via header link
- utility to fetch and cache ACS variable metadata

## Testing
- `npm run lint`
- `NEXT_PUBLIC_INSTANT_APP_ID=demo npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a242c3c494832dbf98117588572db0