### PR TITLE
Add census metrics chat via OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+### Environment Variables
+
+Create a `.env.local` file with your OpenRouter API key:
+
+```
+OPENROUTER_KEY=your_key_here
+```
+
+This key enables the census chat feature powered by the `openai/gpt-5-mini` model on OpenRouter.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from 'next/server';
+
+const OPENROUTER_KEY = process.env.OPENROUTER_KEY;
+
+type CensusVariable = { label: string; concept: string };
+
+async function searchCensusMetrics(query: string) {
+  const res = await fetch('https://api.census.gov/data/2022/acs/acs5/variables.json');
+  const data = await res.json();
+  const entries = Object.entries(data.variables as Record<string, CensusVariable>);
+  const matches = entries
+    .filter(([name, info]) =>
+      name.toLowerCase().includes(query.toLowerCase()) ||
+      info.label.toLowerCase().includes(query.toLowerCase())
+    )
+    .slice(0, 5)
+    .map(([name, info]) => ({ name, label: info.label, concept: info.concept }));
+  return matches;
+}
+
+const tools = [
+  {
+    type: 'function',
+    function: {
+      name: 'search_census_metrics',
+      description: 'Search US Census ACS 5-year 2022 variables matching a query string',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Search term for census variable labels or names' }
+        },
+        required: ['query']
+      }
+    }
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'add_metric',
+      description: 'Add a census metric to the selection dropdown',
+      parameters: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Census variable name' },
+          label: { type: 'string', description: 'Human readable label for the variable' }
+        },
+        required: ['name', 'label']
+      }
+    }
+  }
+];
+
+type ChatMessage = { role: string; content?: string; [key: string]: unknown };
+
+async function callOpenRouter(messages: ChatMessage[]) {
+  const resp = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${OPENROUTER_KEY}`,
+      'HTTP-Referer': 'https://example.com',
+      'X-Title': 'NEProto'
+    },
+    body: JSON.stringify({ model: 'openai/gpt-5-mini', messages, tools })
+  });
+  return resp.json();
+}
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const history: ChatMessage[] = [
+    {
+      role: 'system',
+      content: 'You help users explore metrics from the US Census. Use tools to search for metrics and add them when asked.'
+    },
+    ...messages
+  ];
+
+  let addedMetric: { name: string; label: string } | null = null;
+
+  for (let i = 0; i < 3; i++) {
+    const data = await callOpenRouter(history);
+    const msg = data.choices?.[0]?.message;
+    if (!msg) break;
+
+    if (msg.tool_calls && msg.tool_calls.length > 0) {
+      history.push(msg);
+      for (const call of msg.tool_calls) {
+        const args = JSON.parse(call.function.arguments || '{}');
+        if (call.function.name === 'search_census_metrics') {
+          const result = await searchCensusMetrics(args.query);
+          history.push({ role: 'tool', tool_call_id: call.id, content: JSON.stringify(result) });
+        } else if (call.function.name === 'add_metric') {
+          addedMetric = { name: args.name, label: args.label };
+          history.push({ role: 'tool', tool_call_id: call.id, content: 'added' });
+        }
+      }
+      continue;
+    }
+
+    return NextResponse.json({ reply: msg.content, addedMetric });
+  }
+
+  return NextResponse.json({ reply: 'Unable to complete request.', addedMetric });
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import db from '../lib/db';
 import AddOrganizationForm from '../components/AddOrganizationForm';
 import CircularAddButton from '../components/CircularAddButton';
+import CensusChat from '../components/CensusChat';
 import type { Organization } from '../types/organization';
 
 const OKCMap = dynamic(() => import('../components/OKCMap'), {
@@ -15,6 +16,12 @@ const OKCMap = dynamic(() => import('../components/OKCMap'), {
 export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
+  const [metrics, setMetrics] = useState<{ name: string; label: string }[]>([]);
+  const [selectedMetric, setSelectedMetric] = useState('');
+
+  const handleAddMetric = (metric: { name: string; label: string }) => {
+    setMetrics((m) => [...m, metric]);
+  };
 
   const { data, isLoading, error } = db.useQuery({
     organizations: {
@@ -54,9 +61,27 @@ export default function Home() {
         </div>
       </header>
 
+      <div className="max-w-7xl mx-auto p-4 space-y-4">
+        <div>
+          <select
+            value={selectedMetric}
+            onChange={(e) => setSelectedMetric(e.target.value)}
+            className="w-full md:w-80 border rounded px-3 py-2"
+          >
+            <option value="">Select a metric</option>
+            {metrics.map((m) => (
+              <option key={m.name} value={m.name}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <CensusChat onAddMetric={handleAddMetric} />
+      </div>
+
       <div className="flex">
         <div className="flex-1 h-screen relative">
-          <OKCMap 
+          <OKCMap
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
           />

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatProps {
+  onAddMetric: (metric: { name: string; label: string }) => void;
+}
+
+export default function CensusChat({ onAddMetric }: ChatProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const newMessages = [...messages, { role: 'user', content: input }];
+    setMessages(newMessages);
+    setInput('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: newMessages })
+      });
+      const data = await res.json();
+      if (data.reply) {
+        setMessages([...newMessages, { role: 'assistant', content: data.reply }]);
+      }
+      if (data.addedMetric) {
+        onAddMetric(data.addedMetric);
+      }
+    } catch {
+      setMessages([...newMessages, { role: 'assistant', content: 'Error getting response.' }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white border rounded p-4 space-y-2">
+      <div className="h-40 overflow-y-auto space-y-1 text-sm">
+        {messages.map((m, i) => (
+          <div key={i} className={m.role === 'user' ? 'text-right' : ''}>
+            <span className="inline-block px-2 py-1 rounded bg-gray-100">{m.content}</span>
+          </div>
+        ))}
+        {loading && <div className="text-gray-400">Thinking...</div>}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border rounded px-3 py-2"
+          placeholder="Ask about US Census metrics"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && sendMessage()}
+        />
+        <button
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={sendMessage}
+          disabled={loading}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/api/chat` route that uses OpenRouter `openai/gpt-5-mini` with tools for searching US Census variables and adding metrics
- implement `CensusChat` component for interactive metric discovery and selection
- integrate chat and metric dropdown into main page and document `OPENROUTER_KEY`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a271291648832dab5d80748bd4beb7