### PR TITLE
Sync metric selection across map and data views

### DIFF
--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -1,21 +1,33 @@
-import { fetchZctaMetric } from '../../lib/census';
+'use client';
 
-export const dynamic = 'force-dynamic';
+import MetricDropdown from '../../components/MetricDropdown';
+import { useMetrics } from '../../components/MetricsContext';
 
-export default async function DataPage() {
-  const features = await fetchZctaMetric('B19013_001E');
+export default function DataPage() {
+  const { metrics, selectedMetric, zctaFeatures, selectMetric } = useMetrics();
+  const selected = metrics.find(m => m.id === selectedMetric);
+
   return (
     <div className="max-w-4xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4">Median Household Income (ACS 2021 5-year)</h1>
+      {metrics.length > 0 && (
+        <div className="mb-4">
+          <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
+        </div>
+      )}
+      {selected ? (
+        <h1 className="text-2xl font-bold mb-4">{selected.label}</h1>
+      ) : (
+        <p className="text-gray-700 mb-4">add a metric to see on table and map</p>
+      )}
       <table className="min-w-full text-sm border">
         <thead>
           <tr>
             <th className="border px-2 py-1 text-left">ZCTA</th>
-            <th className="border px-2 py-1 text-left">Median Income</th>
+            <th className="border px-2 py-1 text-left">Value</th>
           </tr>
         </thead>
         <tbody>
-          {features.map((f) => (
+          {zctaFeatures?.map(f => (
             <tr key={f.properties.ZCTA5CE10}>
               <td className="border px-2 py-1">{f.properties.ZCTA5CE10}</td>
               <td className="border px-2 py-1">{f.properties.value ?? 'N/A'}</td>
@@ -26,3 +38,4 @@ export default async function DataPage() {
     </div>
   );
 }
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import MetricsProvider from "../components/MetricsContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased h-screen overflow-hidden`}
       >
-        {children}
+        <MetricsProvider>
+          {children}
+        </MetricsProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import AddOrganizationForm from '../components/AddOrganizationForm';
 import CircularAddButton from '../components/CircularAddButton';
 import CensusChat from '../components/CensusChat';
 import MetricDropdown from '../components/MetricDropdown';
-import { fetchZctaMetric, type ZctaFeature } from '../lib/census';
+import { useMetrics } from '../components/MetricsContext';
 import type { Organization } from '../types/organization';
 
 const OKCMap = dynamic(() => import('../components/OKCMap'), {
@@ -18,33 +18,7 @@ const OKCMap = dynamic(() => import('../components/OKCMap'), {
 export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
-  const [metrics, setMetrics] = useState<{ id: string; label: string }[]>([]);
-  const [selectedMetric, setSelectedMetric] = useState<string | null>(null);
-  const [zctaFeatures, setZctaFeatures] = useState<ZctaFeature[] | undefined>();
-  const [metricFeatures, setMetricFeatures] = useState<Record<string, ZctaFeature[]>>({});
-
-  const addMetric = async (m: { id: string; label: string }) => {
-    setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
-    setSelectedMetric(m.id);
-    let features = metricFeatures[m.id];
-    if (!features) {
-      const varId = m.id.includes('_') ? m.id : m.id + '_001E';
-      features = await fetchZctaMetric(varId);
-      setMetricFeatures(prev => ({ ...prev, [m.id]: features! }));
-    }
-    setZctaFeatures(features);
-  };
-
-  const handleMetricSelect = async (id: string) => {
-    setSelectedMetric(id);
-    let features = metricFeatures[id];
-    if (!features) {
-      const varId = id.includes('_') ? id : id + '_001E';
-      features = await fetchZctaMetric(varId);
-      setMetricFeatures(prev => ({ ...prev, [id]: features! }));
-    }
-    setZctaFeatures(features);
-  };
+  const { metrics, selectedMetric, zctaFeatures, addMetric, selectMetric } = useMetrics();
 
   const { data, isLoading, error } = db.useQuery({
     organizations: {
@@ -82,7 +56,7 @@ export default function Home() {
           </div>
           <div className="flex items-center gap-4">
             <a href="/data" className="text-blue-600 underline text-sm">Data</a>
-            <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={handleMetricSelect} />
+            <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
             <CircularAddButton onClick={() => setShowAddForm(true)} />
           </div>
         </div>
@@ -118,29 +92,29 @@ export default function Home() {
                   </div>
                 )}
                 
-                <div className="space-y-2 text-sm">
+                <div className="space-y-2 text-sm text-gray-900">
                   {selectedOrg.website && (
                     <div>
-                      <span className="font-medium">Website: </span>
-                      <a href={selectedOrg.website} target="_blank" rel="noopener noreferrer" 
+                      <span className="font-medium text-gray-900">Website: </span>
+                      <a href={selectedOrg.website} target="_blank" rel="noopener noreferrer"
                          className="text-blue-600 hover:underline">
                         {selectedOrg.website}
                       </a>
                     </div>
                   )}
-                  
+
                   {selectedOrg.phone && (
                     <div>
-                      <span className="font-medium">Phone: </span>
+                      <span className="font-medium text-gray-900">Phone: </span>
                       <a href={`tel:${selectedOrg.phone}`} className="text-blue-600">
                         {selectedOrg.phone}
                       </a>
                     </div>
                   )}
-                  
+
                   {selectedOrg.email && (
                     <div>
-                      <span className="font-medium">Email: </span>
+                      <span className="font-medium text-gray-900">Email: </span>
                       <a href={`mailto:${selectedOrg.email}`} className="text-blue-600">
                         {selectedOrg.email}
                       </a>

--- a/components/MetricsContext.tsx
+++ b/components/MetricsContext.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+import { fetchZctaMetric, type ZctaFeature } from '../lib/census';
+
+interface Metric {
+  id: string;
+  label: string;
+}
+
+interface MetricsContextValue {
+  metrics: Metric[];
+  selectedMetric: string | null;
+  zctaFeatures?: ZctaFeature[];
+  addMetric: (metric: Metric) => Promise<void>;
+  selectMetric: (id: string) => Promise<void>;
+}
+
+const MetricsContext = createContext<MetricsContextValue | undefined>(undefined);
+
+export function MetricsProvider({ children }: { children: React.ReactNode }) {
+  const [metrics, setMetrics] = useState<Metric[]>([]);
+  const [selectedMetric, setSelectedMetric] = useState<string | null>(null);
+  const [zctaFeatures, setZctaFeatures] = useState<ZctaFeature[] | undefined>();
+  const [metricFeatures, setMetricFeatures] = useState<Record<string, ZctaFeature[]>>({});
+
+  const selectMetric = async (id: string) => {
+    setSelectedMetric(id);
+    let features = metricFeatures[id];
+    if (!features) {
+      const varId = id.includes('_') ? id : id + '_001E';
+      features = await fetchZctaMetric(varId);
+      setMetricFeatures(prev => ({ ...prev, [id]: features }));
+    }
+    setZctaFeatures(features);
+  };
+
+  const addMetric = async (metric: Metric) => {
+    setMetrics(prev => (prev.find(m => m.id === metric.id) ? prev : [...prev, metric]));
+    await selectMetric(metric.id);
+  };
+
+  return (
+    <MetricsContext.Provider value={{ metrics, selectedMetric, zctaFeatures, addMetric, selectMetric }}>
+      {children}
+    </MetricsContext.Provider>
+  );
+}
+
+export function useMetrics() {
+  const ctx = useContext(MetricsContext);
+  if (!ctx) throw new Error('useMetrics must be used within MetricsProvider');
+  return ctx;
+}
+
+export default MetricsProvider;
+


### PR DESCRIPTION
## Summary
- Share metrics and selected values between pages with a new `MetricsContext`
- Revamp Data page to wait for user-added metrics and mirror dropdown selection
- Improve readability of Website/Phone/Email labels in org details panel

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a36dbc9f30832d93ee976ac5dcad7d