### PR TITLE
Optimize Census data retrieval

### DIFF
--- a/lib/census.ts
+++ b/lib/census.ts
@@ -37,7 +37,7 @@ const OKC_ZCTAS = [
 
 export async function fetchZctaMetric(
   variable: string,
-  year = '2021'
+  year = '2023'
 ): Promise<ZctaFeature[]> {
   const values = new Map<string, number | null>();
 
@@ -47,18 +47,18 @@ export async function fetchZctaMetric(
     message: { type: 'metric', variable, year },
   });
 
-  await Promise.all(
-    OKC_ZCTAS.map(async (zcta) => {
-      const res = await fetch(
-        `https://api.census.gov/data/${year}/acs/acs5?get=${variable}&for=zip%20code%20tabulation%20area:${zcta}`
-      );
-      const json = await res.json();
-      const raw = Number(json[1][0]);
-      // Filter out large negative sentinel values that represent missing data
-      const val = isNaN(raw) || raw < -100000 ? null : raw;
-      values.set(zcta, val);
-    })
+  const zctas = OKC_ZCTAS.join(',');
+  const res = await fetch(
+    `https://api.census.gov/data/${year}/acs/acs5?get=${variable}&for=zip%20code%20tabulation%20area:${zctas}`
   );
+  const json = await res.json();
+  for (let i = 1; i < json.length; i++) {
+    const [rawValue, zcta] = json[i] as [string, string];
+    const raw = Number(rawValue);
+    // Filter out large negative sentinel values that represent missing data
+    const val = isNaN(raw) || raw < -100000 ? null : raw;
+    values.set(zcta, val);
+  }
 
   const geoRes = await fetch(
     'https://raw.githubusercontent.com/OpenDataDE/State-zip-code-GeoJSON/master/ok_oklahoma_zip_codes_geo.min.json'

--- a/lib/censusVariables.ts
+++ b/lib/censusVariables.ts
@@ -1,0 +1,33 @@
+export interface CensusVariable {
+  id: string;
+  label: string;
+  concept: string;
+  keywords: string[];
+}
+
+export const CENSUS_VARIABLES: CensusVariable[] = [
+  {
+    id: 'B19013_001E',
+    label: 'Median household income in the past 12 months',
+    concept: 'INCOME IN THE PAST 12 MONTHS (IN 2023 INFLATION-ADJUSTED DOLLARS)',
+    keywords: ['income', 'median', 'household', 'hh'],
+  },
+  {
+    id: 'B19301_001E',
+    label: 'Per capita income in the past 12 months',
+    concept: 'INCOME IN THE PAST 12 MONTHS (IN 2023 INFLATION-ADJUSTED DOLLARS)',
+    keywords: ['income', 'per', 'capita'],
+  },
+  {
+    id: 'B01003_001E',
+    label: 'Total population',
+    concept: 'TOTAL POPULATION',
+    keywords: ['population', 'total'],
+  },
+  {
+    id: 'B01002_001E',
+    label: 'Median age',
+    concept: 'MEDIAN AGE BY SEX',
+    keywords: ['age', 'median'],
+  },
+];


### PR DESCRIPTION
## Summary
- Fetch ACS metrics for all OKC ZCTAs in a single Census API call and default to the 2023 dataset
- Maintain a small curated index of ACS variables for faster searches
- Simplify Census variable search to use the curated index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3ac9090e4832da64b8da2cdb1e8f9