### PR TITLE
Prefetch ZCTA boundaries for quicker metric shading

### DIFF
--- a/components/MetricContext.tsx
+++ b/components/MetricContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { createContext, useContext, useState } from 'react';
-import { fetchZctaMetric, type ZctaFeature } from '../lib/census';
+import { createContext, useContext, useState, useEffect } from 'react';
+import { fetchZctaMetric, type ZctaFeature, prefetchZctaBoundaries } from '../lib/census';
 import { useConfig } from './ConfigContext';
 
 interface Metric {
@@ -25,6 +25,10 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
   const [zctaFeatures, setZctaFeatures] = useState<ZctaFeature[] | undefined>();
   const [metricFeatures, setMetricFeatures] = useState<Record<string, ZctaFeature[]>>({});
   const { config } = useConfig();
+
+  useEffect(() => {
+    prefetchZctaBoundaries();
+  }, []);
 
   const addMetric = async (m: Metric) => {
     setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));


### PR DESCRIPTION
## Summary
- Cache Oklahoma ZCTA boundary polygons in memory and expose a prefetch helper
- Preload boundary data on the client so metric requests only fetch census values

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a49dd7ffc0832dafb2c711ef81ad4e