### PR TITLE
Prefetch ZCTA boundary polygons

### DIFF
--- a/components/MetricContext.tsx
+++ b/components/MetricContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { createContext, useContext, useState } from 'react';
-import { fetchZctaMetric, type ZctaFeature } from '../lib/census';
+import { createContext, useContext, useState, useEffect } from 'react';
+import { fetchZctaMetric, preloadZctaBoundaries, type ZctaFeature } from '../lib/census';
 import { useConfig } from './ConfigContext';
 
 interface Metric {
@@ -25,6 +25,10 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
   const [zctaFeatures, setZctaFeatures] = useState<ZctaFeature[] | undefined>();
   const [metricFeatures, setMetricFeatures] = useState<Record<string, ZctaFeature[]>>({});
   const { config } = useConfig();
+
+  useEffect(() => {
+    preloadZctaBoundaries();
+  }, []);
 
   const addMetric = async (m: Metric) => {
     setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));


### PR DESCRIPTION
## Summary
- cache Oklahoma ZCTA boundary GeoJSON locally and expose preload helper
- load boundary polygons at app start so metric requests only fetch census data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49dd7ffc0832dafb2c711ef81ad4e