### PR TITLE
feat: support additional census datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - **Common ACS variables** are listed in `lib/censusVariables.ts` for quick lookup and reduced search latency.
 - **Common query phrases** mapping to ACS variable ids live in `lib/censusQueryMap.ts` to bypass dataset searches for frequent requests.
 - **Metric validation** ensures any selected variable id exists in the 2023 ACS dataset before being added.
-- **Chat controls** at the top of the Census chat let you adjust region, dataset, and year (e.g. 2021 vs 2023) used for queries.
+- **Chat controls** at the top of the Census chat let you adjust region, dataset (ACS, Decennial, Business Patterns), and year (e.g. 2010–2023) used for queries.

--- a/components/ConfigControls.tsx
+++ b/components/ConfigControls.tsx
@@ -22,6 +22,8 @@ export default function ConfigControls() {
         <option value="2023">2023</option>
         <option value="2022">2022</option>
         <option value="2021">2021</option>
+        <option value="2020">2020</option>
+        <option value="2010">2010</option>
       </select>
       <select
         className="border border-gray-300 rounded p-1 text-sm w-full"
@@ -30,6 +32,8 @@ export default function ConfigControls() {
       >
         <option value="acs/acs5">ACS 5-year</option>
         <option value="acs/acs1">ACS 1-year</option>
+        <option value="dec/pl">Decennial Census PL</option>
+        <option value="cbp">County Business Patterns</option>
       </select>
       <select
         className="border border-gray-300 rounded p-1 text-sm w-full"


### PR DESCRIPTION
## Summary
- allow selecting decennial and business datasets in the Census chat config
- document dataset options and broader year range in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49fafff18832d9efc5cc9cc1d2cb7