### PR TITLE
refactor: modularize census chat logic

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { addLog } from '../../../lib/logStore';
-import { CURATED_VARIABLES } from '../../../lib/censusVariables';
-import { COMMON_QUERY_MAP } from '../../../lib/censusQueryMap';
+import { searchCensus, validateVariableId } from '../../../lib/censusTools';
+import { callOpenRouter } from '../../../lib/openRouter';
 
 interface Message {
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -9,112 +8,6 @@ interface Message {
   tool_call_id?: string;
 }
 
-interface CensusVariable {
-  id: string;
-  label: string;
-  concept: string;
-}
-
-const variablesCache = new Map<string, Array<[string, { label: string; concept: string }]>>();
-const searchCache = new Map<string, CensusVariable[]>();
-
-async function loadVariables(year: string, dataset: string) {
-  const key = `${dataset}-${year}`;
-  if (!variablesCache.has(key)) {
-    addLog({
-      service: 'US Census',
-      direction: 'request',
-      message: { endpoint: 'variables.json', year, dataset },
-    });
-    const resp = await fetch(
-      `https://api.census.gov/data/${year}/${dataset}/variables.json`
-    );
-    const json = await resp.json();
-    addLog({
-      service: 'US Census',
-      direction: 'response',
-      message: { variables: Object.keys(json.variables).length, year, dataset },
-    });
-    variablesCache.set(
-      key,
-      Object.entries(json.variables as Record<string, { label: string; concept: string }>)
-    );
-  }
-  return variablesCache.get(key)!;
-}
-
-async function validateVariableId(id: string, year: string, dataset: string) {
-  if (CURATED_VARIABLES.some((v) => v.id === id)) return true;
-  const vars = await loadVariables(year, dataset);
-  return vars.some(([vid]) => vid === id);
-}
-
-async function searchCensus(
-  query: string,
-  year: string,
-  dataset: string
-): Promise<CensusVariable[]> {
-  const q = query.toLowerCase().trim();
-  const cacheKey = `${dataset}-${year}-${q}`;
-  if (searchCache.has(cacheKey)) return searchCache.get(cacheKey)!;
-
-  if (COMMON_QUERY_MAP[q]) {
-    const { id, label, concept } = COMMON_QUERY_MAP[q];
-    const result = [{ id, label, concept }];
-    searchCache.set(cacheKey, result);
-    return result;
-  }
-
-  const tokens = q.split(/\s+/);
-  const curated = CURATED_VARIABLES.filter((v) =>
-    tokens.every(
-      (t) =>
-        v.label.toLowerCase().includes(t) ||
-        v.keywords.some((k) => k.includes(t))
-    )
-  ).map(({ id, label, concept }) => ({ id, label, concept }));
-
-  if (curated.length) {
-    searchCache.set(cacheKey, curated);
-    return curated;
-  }
-
-  const vars = await loadVariables(year, dataset);
-  addLog({
-    service: 'US Census',
-    direction: 'request',
-    message: { type: 'search', query, year, dataset },
-  });
-  const results = vars
-    .filter(([, info]) => info.label.toLowerCase().includes(q))
-    .slice(0, 5)
-    .map(([id, info]) => ({ id, label: info.label, concept: info.concept }));
-  searchCache.set(cacheKey, results);
-  addLog({
-    service: 'US Census',
-    direction: 'response',
-    message: results,
-  });
-  return results;
-}
-
-async function callOpenRouter(payload: Record<string, unknown>) {
-  addLog({ service: 'OpenRouter', direction: 'request', message: payload });
-  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.OPENROUTER_KEY}`,
-    },
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) {
-    throw new Error(`OpenRouter error: ${res.status}`);
-  }
-  const json = await res.json();
-  addLog({ service: 'OpenRouter', direction: 'response', message: json });
-  return json;
-}
 
 export async function POST(req: NextRequest) {
   const { messages, config } = await req.json();

--- a/lib/censusTools.ts
+++ b/lib/censusTools.ts
@@ -1,0 +1,90 @@
+import { addLog } from './logStore';
+import { CURATED_VARIABLES } from './censusVariables';
+import { COMMON_QUERY_MAP } from './censusQueryMap';
+
+export interface CensusVariable {
+  id: string;
+  label: string;
+  concept: string;
+}
+
+const variablesCache = new Map<string, Array<[string, { label: string; concept: string }]>>();
+const searchCache = new Map<string, CensusVariable[]>();
+
+export async function loadVariables(year: string, dataset: string) {
+  const key = `${dataset}-${year}`;
+  if (!variablesCache.has(key)) {
+    addLog({
+      service: 'US Census',
+      direction: 'request',
+      message: { endpoint: 'variables.json', year, dataset },
+    });
+    const resp = await fetch(`https://api.census.gov/data/${year}/${dataset}/variables.json`);
+    const json = await resp.json();
+    addLog({
+      service: 'US Census',
+      direction: 'response',
+      message: { variables: Object.keys(json.variables).length, year, dataset },
+    });
+    variablesCache.set(
+      key,
+      Object.entries(json.variables as Record<string, { label: string; concept: string }>)
+    );
+  }
+  return variablesCache.get(key)!;
+}
+
+export async function validateVariableId(id: string, year: string, dataset: string) {
+  if (CURATED_VARIABLES.some((v) => v.id === id)) return true;
+  const vars = await loadVariables(year, dataset);
+  return vars.some(([vid]) => vid === id);
+}
+
+export async function searchCensus(
+  query: string,
+  year: string,
+  dataset: string
+): Promise<CensusVariable[]> {
+  const q = query.toLowerCase().trim();
+  const cacheKey = `${dataset}-${year}-${q}`;
+  if (searchCache.has(cacheKey)) return searchCache.get(cacheKey)!;
+
+  if (COMMON_QUERY_MAP[q]) {
+    const { id, label, concept } = COMMON_QUERY_MAP[q];
+    const result = [{ id, label, concept }];
+    searchCache.set(cacheKey, result);
+    return result;
+  }
+
+  const tokens = q.split(/\s+/);
+  const curated = CURATED_VARIABLES.filter((v) =>
+    tokens.every(
+      (t) =>
+        v.label.toLowerCase().includes(t) ||
+        v.keywords.some((k) => k.includes(t))
+    )
+  ).map(({ id, label, concept }) => ({ id, label, concept }));
+
+  if (curated.length) {
+    searchCache.set(cacheKey, curated);
+    return curated;
+  }
+
+  const vars = await loadVariables(year, dataset);
+  addLog({
+    service: 'US Census',
+    direction: 'request',
+    message: { type: 'search', query, year, dataset },
+  });
+  const results = vars
+    .filter(([, info]) => info.label.toLowerCase().includes(q))
+    .slice(0, 5)
+    .map(([id, info]) => ({ id, label: info.label, concept: info.concept }));
+  searchCache.set(cacheKey, results);
+  addLog({
+    service: 'US Census',
+    direction: 'response',
+    message: results,
+  });
+  return results;
+}

--- a/lib/openRouter.ts
+++ b/lib/openRouter.ts
@@ -1,0 +1,19 @@
+import { addLog } from './logStore';
+
+export async function callOpenRouter(payload: Record<string, unknown>) {
+  addLog({ service: 'OpenRouter', direction: 'request', message: payload });
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENROUTER_KEY}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`OpenRouter error: ${res.status}`);
+  }
+  const json = await res.json();
+  addLog({ service: 'OpenRouter', direction: 'response', message: json });
+  return json;
+}


### PR DESCRIPTION
## Summary
- extract census variable loading, validation, and search helpers into `lib/censusTools.ts`
- move OpenRouter API request handling into `lib/openRouter.ts`
- simplify chat route by importing these helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4a4cef900832dba9d0a1344a5e735