### PR TITLE
feat: add user mode and stat management

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { searchCensus, validateVariableId } from '../../../lib/censusTools';
+import { searchStats } from '../../../lib/statsTools';
 import { callOpenRouter } from '../../../lib/openRouter';
 
 interface Message {
@@ -10,45 +11,82 @@ interface Message {
 
 
 export async function POST(req: NextRequest) {
-  const { messages, config } = await req.json();
+  const { messages, config, mode = 'user' } = await req.json();
   const { year = '2023', dataset = 'acs/acs5' } = config || {};
 
-  const tools = [
-    {
-      type: 'function',
-      function: {
-        name: 'search_census',
-        description:
-          `Search the US Census ${year} ${dataset} dataset for variables matching a query. Returns a list of matching variable ids and descriptions.`,
-        parameters: {
-          type: 'object',
-          properties: {
-            query: {
-              type: 'string',
-              description: 'Search term for the desired statistic',
+  const tools =
+    mode === 'admin'
+      ? [
+          {
+            type: 'function',
+            function: {
+              name: 'search_census',
+              description: `Search the US Census ${year} ${dataset} dataset for variables matching a query. Returns a list of matching variable ids and descriptions.`,
+              parameters: {
+                type: 'object',
+                properties: {
+                  query: {
+                    type: 'string',
+                    description: 'Search term for the desired statistic',
+                  },
+                },
+                required: ['query'],
+              },
             },
           },
-          required: ['query'],
-        },
-      },
-    },
-    {
-      type: 'function',
-      function: {
-        name: 'add_metric',
-        description:
-          "Add a Census variable to the user's metric selection dropdown. Provide the variable id and a human readable label.",
-        parameters: {
-          type: 'object',
-          properties: {
-            id: { type: 'string', description: 'Variable identifier' },
-            label: { type: 'string', description: 'Human readable label' },
+          {
+            type: 'function',
+            function: {
+              name: 'add_metric',
+              description:
+                "Add a Census variable to the user's metric selection dropdown. Provide the variable id and a human readable label.",
+              parameters: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string', description: 'Variable identifier' },
+                  label: { type: 'string', description: 'Human readable label' },
+                },
+                required: ['id', 'label'],
+              },
+            },
           },
-          required: ['id', 'label'],
-        },
-      },
-    },
-  ];
+        ]
+      : [
+          {
+            type: 'function',
+            function: {
+              name: 'search_stats',
+              description:
+                'Search the local stats database for variables matching a query. Returns a list of variable ids and descriptions.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  query: {
+                    type: 'string',
+                    description: 'Search term for the desired statistic',
+                  },
+                },
+                required: ['query'],
+              },
+            },
+          },
+          {
+            type: 'function',
+            function: {
+              name: 'add_metric',
+              description:
+                "Add a stored variable to the user's metric selection dropdown. Provide the variable id and a human readable label.",
+              parameters: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string', description: 'Variable identifier' },
+                  label: { type: 'string', description: 'Human readable label' },
+                },
+                required: ['id', 'label'],
+              },
+            },
+          },
+        ];
 
   const convo: Message[] = [...messages];
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
@@ -80,13 +118,20 @@ export async function POST(req: NextRequest) {
       let result: unknown;
       if (name === 'search_census') {
         result = await searchCensus(args.query as string, year, dataset);
+      } else if (name === 'search_stats') {
+        result = await searchStats(args.query as string);
       } else if (name === 'add_metric') {
-        const id = args.id as string;
-        if (await validateVariableId(id, year, dataset)) {
+        if (mode === 'admin') {
+          const id = args.id as string;
+          if (await validateVariableId(id, year, dataset)) {
+            result = { ok: true };
+            toolInvocations.push({ name, args });
+          } else {
+            result = { ok: false, error: 'Unknown variable id' };
+          }
+        } else {
           result = { ok: true };
           toolInvocations.push({ name, args });
-        } else {
-          result = { ok: false, error: 'Unknown variable id' };
         }
       }
       convo.push({

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import TopNav from '../../components/TopNav';
+import db from '../../lib/db';
+import { fetchZctaMetric } from '../../lib/census';
+import type { Stat } from '../../types/stat';
+
+export default function StatsPage() {
+  const { data } = db.useQuery({ stats: {} });
+  const stats = (data?.stats as Stat[]) || [];
+  const [editing, setEditing] = useState<Record<string, string>>({});
+
+  const handleSave = async (id: string) => {
+    await db.transact([db.tx.stats[id].update({ description: editing[id] })]);
+    setEditing(prev => {
+      const newState = { ...prev };
+      delete newState[id];
+      return newState;
+    });
+  };
+
+  const handleDelete = async (id: string) => {
+    await db.transact([db.tx.stats[id].delete()]);
+  };
+
+  const handleRefresh = async (stat: Stat) => {
+    const varId = stat.variableId.includes('_') ? stat.variableId : stat.variableId + '_001E';
+    const features = await fetchZctaMetric(varId, { year: stat.year, dataset: stat.dataset });
+    const values: Record<string, number | null> = {};
+    for (const f of features || []) {
+      values[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+    }
+    await db.transact([db.tx.stats[stat.id].update({ values })]);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      <TopNav linkHref="/" linkText="Map" />
+      <main className="flex-1 max-w-5xl mx-auto p-4 w-full overflow-x-auto">
+        <h2 className="text-xl font-semibold mb-4">Stat Management</h2>
+        <table className="min-w-full text-sm border">
+          <thead>
+            <tr>
+              <th className="border px-2 py-1 text-left">Title</th>
+              <th className="border px-2 py-1 text-left">Description</th>
+              <th className="border px-2 py-1 text-left">Category</th>
+              <th className="border px-2 py-1 text-left">Dataset</th>
+              <th className="border px-2 py-1 text-left">Year</th>
+              <th className="border px-2 py-1 text-left">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.map((s: Stat) => (
+              <tr key={s.id}>
+                <td className="border px-2 py-1">{s.title}</td>
+                <td className="border px-2 py-1">
+                  <input
+                    className="border p-1 w-full"
+                    value={editing[s.id] ?? s.description}
+                    onChange={e => setEditing(prev => ({ ...prev, [s.id]: e.target.value }))}
+                  />
+                </td>
+                <td className="border px-2 py-1">{s.category || ''}</td>
+                <td className="border px-2 py-1">{s.source}</td>
+                <td className="border px-2 py-1">{s.year}</td>
+                <td className="border px-2 py-1 space-x-2">
+                  <button className="text-blue-600" onClick={() => handleSave(s.id)}>Save</button>
+                  <button className="text-red-600" onClick={() => handleDelete(s.id)}>Delete</button>
+                  <button className="text-green-600" onClick={() => handleRefresh(s)}>Refresh</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </main>
+    </div>
+  );
+}

--- a/components/MetricContext.tsx
+++ b/components/MetricContext.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect } from 'react';
+import { id as genId } from '@instantdb/react';
 import { fetchZctaMetric, type ZctaFeature, prefetchZctaBoundaries } from '../lib/census';
+import db from '../lib/db';
 import { useConfig } from './ConfigContext';
+import type { Stat } from '../types/stat';
 
 interface Metric {
   id: string;
@@ -14,7 +17,7 @@ interface MetricsContextValue {
   selectedMetric: string | null;
   zctaFeatures: ZctaFeature[] | undefined;
   addMetric: (metric: Metric) => Promise<void>;
-  selectMetric: (id: string) => Promise<void>;
+  selectMetric: (id: string, label?: string) => Promise<void>;
 }
 
 const MetricsContext = createContext<MetricsContextValue | undefined>(undefined);
@@ -25,6 +28,8 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
   const [zctaFeatures, setZctaFeatures] = useState<ZctaFeature[] | undefined>();
   const [metricFeatures, setMetricFeatures] = useState<Record<string, ZctaFeature[]>>({});
   const { config } = useConfig();
+  const { data: statsData } = db.useQuery({ stats: {} });
+  const stats = (statsData?.stats as Stat[]) ?? [];
 
   useEffect(() => {
     prefetchZctaBoundaries();
@@ -32,17 +37,49 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
 
   const addMetric = async (m: Metric) => {
     setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
-    await selectMetric(m.id);
+    await selectMetric(m.id, m.label);
   };
 
-  const selectMetric = async (id: string) => {
+  const selectMetric = async (id: string, label?: string) => {
     setSelectedMetric(id);
     const key = `${config.dataset}-${config.year}-${id}`;
     let features = metricFeatures[key];
     if (!features) {
-      const varId = id.includes('_') ? id : id + '_001E';
-      features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
-      setMetricFeatures(prev => ({ ...prev, [key]: features! }));
+      const existing = stats.find(
+        (s) => s.variableId === id && s.dataset === config.dataset && s.year === config.year
+      );
+      if (existing) {
+        const boundaries = await prefetchZctaBoundaries();
+        const values = existing.values || {};
+        features = boundaries?.map(f => ({
+          ...f,
+          properties: { ...f.properties, value: values[f.properties.ZCTA5CE10] ?? null },
+        }));
+      } else {
+        const varId = id.includes('_') ? id : id + '_001E';
+        features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
+        if (label && features) {
+          const values: Record<string, number | null> = {};
+          for (const f of features) {
+            values[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+          }
+          const statId = genId();
+          await db.transact([
+            db.tx.stats[statId].update({
+              variableId: id,
+              title: label,
+              description: label,
+              dataset: config.dataset,
+              year: config.year,
+              source: 'US Census',
+              values,
+            }),
+          ]);
+        }
+      }
+      if (features) {
+        setMetricFeatures(prev => ({ ...prev, [key]: features! }));
+      }
     }
     setZctaFeatures(features);
   };

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -25,6 +25,9 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
           <Link href={linkHref} className="text-blue-600 underline text-sm">
             {linkText}
           </Link>
+          <Link href="/stats" className="text-blue-600 underline text-sm">
+            Stat Management
+          </Link>
           <Link href="/logs" className="text-blue-600 underline text-sm">
             Logs
           </Link>

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -25,6 +25,16 @@ const _schema = i.schema({
       longitude: i.number(),
       isPrimary: i.boolean(),
     }),
+    stats: i.entity({
+      variableId: i.string().indexed(),
+      title: i.string(),
+      description: i.string(),
+      category: i.string().optional(),
+      dataset: i.string(),
+      year: i.string(),
+      source: i.string(),
+      values: i.json(),
+    }),
   },
   links: {
     orgLocations: {

--- a/lib/adminDb.ts
+++ b/lib/adminDb.ts
@@ -1,0 +1,9 @@
+import { init } from '@instantdb/admin';
+import schema from '../instant.schema';
+
+const APP_ID = process.env.NEXT_PUBLIC_INSTANT_APP_ID!;
+const ADMIN_TOKEN = process.env.INSTANT_ADMIN_TOKEN!;
+
+const adminDb = init({ appId: APP_ID, adminToken: ADMIN_TOKEN, schema });
+
+export default adminDb;

--- a/lib/statsTools.ts
+++ b/lib/statsTools.ts
@@ -1,0 +1,22 @@
+import adminDb from './adminDb';
+
+export async function searchStats(query: string) {
+  const res = await adminDb.query({
+    stats: {
+      $: {
+        where: {
+          or: [
+            { title: { $ilike: `%${query}%` } },
+            { description: { $ilike: `%${query}%` } },
+          ],
+        },
+      },
+    },
+  });
+  return (
+    res.stats?.map((s: { variableId: string; description: string }) => ({
+      id: s.variableId,
+      description: s.description,
+    })) || []
+  );
+}

--- a/types/stat.ts
+++ b/types/stat.ts
@@ -1,0 +1,11 @@
+export interface Stat {
+  id: string;
+  variableId: string;
+  title: string;
+  description: string;
+  category?: string;
+  dataset: string;
+  year: string;
+  source: string;
+  values: Record<string, number | null>;
+}


### PR DESCRIPTION
## Summary
- add stats entity to InstantDB schema and persist metric data
- support user and admin chat modes with local stat searching
- provide stat management page with edit, delete, and refresh actions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4b93c9698832d934b21ca1587dbb7