### PR TITLE
feat: add user mode and stat management

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { id } from '@instantdb/react';
+import TopNav from '../../components/TopNav';
+import db from '../../lib/db';
+import { fetchZctaMetric } from '../../lib/census';
+
+interface StatValue { id: string; zcta: string; value: number | null | undefined }
+interface Stat { id: string; title: string; description: string; variable: string; dataset: string; year: number; values: StatValue[] }
+
+export default function StatsPage() {
+  const { data, isLoading, error } = db.useQuery({ stats: { values: {} } });
+  const stats: Stat[] = data?.stats || [];
+
+  const handleSave = async (statId: string, description: string) => {
+    await db.transact([db.tx.stats[statId].update({ description })]);
+  };
+
+  const handleDelete = async (statId: string, valueIds: string[]) => {
+    await db.transact([
+      ...valueIds.map(v => db.tx.statValues[v].delete()),
+      db.tx.stats[statId].delete(),
+    ]);
+  };
+
+  const handleRefresh = async (stat: Stat) => {
+    const variable = stat.variable.includes('_') ? stat.variable : stat.variable + '_001E';
+    const features = await fetchZctaMetric(variable, { year: String(stat.year), dataset: stat.dataset });
+    const valueTx = features.map(f => {
+      const vid = id();
+      return db.tx.statValues[vid]
+        .update({ zcta: f.properties.ZCTA5CE10, value: f.properties.value ?? undefined })
+        .link({ stat: stat.id });
+    });
+    const deleteTx = stat.values.map(v => db.tx.statValues[v.id].delete());
+    await db.transact([...deleteTx, ...valueTx]);
+  };
+
+  if (isLoading) {
+    return <div className="min-h-screen bg-gray-100 flex items-center justify-center">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="min-h-screen bg-gray-100 flex items-center justify-center text-red-500">Error loading stats: {error.message}</div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      <TopNav linkHref="/" linkText="Map" />
+      <main className="flex-1 max-w-4xl mx-auto p-4 w-full">
+        <h2 className="text-xl font-semibold mb-4">Stats</h2>
+        <table className="min-w-full text-sm border">
+          <thead>
+            <tr>
+              <th className="border px-2 py-1 text-left">Title</th>
+              <th className="border px-2 py-1 text-left">Description</th>
+              <th className="border px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.map((s) => (
+              <tr key={s.id}>
+                <td className="border px-2 py-1">{s.title}</td>
+                <td className="border px-2 py-1">
+                  <input
+                    className="w-full border px-1 py-0.5"
+                    defaultValue={s.description}
+                    onBlur={e => handleSave(s.id, e.target.value)}
+                  />
+                </td>
+                <td className="border px-2 py-1 space-x-2">
+                  <button className="text-blue-600 underline" onClick={() => handleRefresh(s)}>Refresh</button>
+                  <button className="text-red-600 underline" onClick={() => handleDelete(s.id, s.values.map(v => v.id))}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </main>
+    </div>
+  );
+}

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -3,20 +3,28 @@
 import { useState } from 'react';
 import { useConfig } from './ConfigContext';
 import ConfigControls from './ConfigControls';
+import db from '../lib/db';
+import { getVariableInfo } from '../lib/censusTools';
+import { fetchZctaMetric, featuresFromStatValues, type ZctaFeature } from '../lib/census';
+import { saveStat } from '../lib/stats';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
 }
 
+interface StatValue { zcta: string; value: number | null }
+interface Stat { id: string; title: string; description: string; variable: string; dataset: string; year: number; values: StatValue[] }
+
 interface CensusChatProps {
-  onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
+  onAddMetric: (metric: { id: string; label: string; features?: ZctaFeature[] }) => void | Promise<void>;
 }
 
 export default function CensusChat({ onAddMetric }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [mode, setMode] = useState<'user' | 'admin'>('user');
   const { config } = useConfig();
 
   const sendMessage = async () => {
@@ -26,32 +34,78 @@ export default function CensusChat({ onAddMetric }: CensusChatProps) {
     setInput('');
     setLoading(true);
 
-    const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
-        config,
-      }),
-    });
-    const data = await res.json();
-    setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
-    setLoading(false);
+    if (mode === 'admin') {
+      const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
+          config,
+        }),
+      });
+      const data = await res.json();
+      setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
+      setLoading(false);
 
-    if (data.toolInvocations) {
-      for (const inv of data.toolInvocations) {
-        if (inv.name === 'add_metric') {
-          await onAddMetric(inv.args);
+      if (data.toolInvocations) {
+        for (const inv of data.toolInvocations) {
+          if (inv.name === 'add_metric') {
+            const info = await getVariableInfo(inv.args.id, config.year, config.dataset);
+            const varId = inv.args.id.includes('_') ? inv.args.id : inv.args.id + '_001E';
+            const features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
+            await saveStat({
+              variable: inv.args.id,
+              title: inv.args.label,
+              description: info?.label || inv.args.label,
+              category: info?.concept || '',
+              dataset: config.dataset,
+              year: config.year,
+              features,
+            });
+            await onAddMetric({ id: inv.args.id, label: inv.args.label, features });
+          }
         }
       }
+    } else {
+      const result = await db.query({ stats: { values: {} } });
+      const stats: Stat[] = result.stats || [];
+      const q = input.toLowerCase();
+      const matches = stats.filter((s) =>
+        s.title.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)
+      );
+      if (matches.length) {
+        const stat = matches[0];
+        const features = await featuresFromStatValues(
+          stat.values.map((v) => ({ zcta: v.zcta, value: v.value ?? null }))
+        );
+        await onAddMetric({ id: stat.variable, label: stat.title, features });
+        setMessages([...newMessages, { role: 'assistant', content: stat.description }]);
+      } else {
+        setMessages([...newMessages, { role: 'assistant', content: 'No stats found.' }]);
+      }
+      setLoading(false);
     }
   };
 
-  return (
-    <div className="flex flex-col h-full bg-white text-gray-900">
-      <ConfigControls />
-      <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
+    return (
+      <div className="flex flex-col h-full bg-white text-gray-900">
+        <div className="flex justify-center gap-2 mb-1 text-sm">
+          <button
+            className={`px-2 py-1 border rounded ${mode === 'user' ? 'bg-blue-500 text-white' : ''}`}
+            onClick={() => setMode('user')}
+          >
+            User Mode
+          </button>
+          <button
+            className={`px-2 py-1 border rounded ${mode === 'admin' ? 'bg-blue-500 text-white' : ''}`}
+            onClick={() => setMode('admin')}
+          >
+            Admin Mode
+          </button>
+        </div>
+        <ConfigControls />
+        <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
         {messages.map((m, idx) => (
           <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
             <span
@@ -69,7 +123,7 @@ export default function CensusChat({ onAddMetric }: CensusChatProps) {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
-          placeholder="Ask about US Census stats..."
+          placeholder="Ask about stats..."
         />
         <button
           className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"

--- a/components/MetricContext.tsx
+++ b/components/MetricContext.tsx
@@ -7,6 +7,7 @@ import { useConfig } from './ConfigContext';
 interface Metric {
   id: string;
   label: string;
+  features?: ZctaFeature[];
 }
 
 interface MetricsContextValue {
@@ -14,7 +15,7 @@ interface MetricsContextValue {
   selectedMetric: string | null;
   zctaFeatures: ZctaFeature[] | undefined;
   addMetric: (metric: Metric) => Promise<void>;
-  selectMetric: (id: string) => Promise<void>;
+  selectMetric: (id: string, features?: ZctaFeature[]) => Promise<void>;
 }
 
 const MetricsContext = createContext<MetricsContextValue | undefined>(undefined);
@@ -31,14 +32,14 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const addMetric = async (m: Metric) => {
-    setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
-    await selectMetric(m.id);
+    setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, { id: m.id, label: m.label }]));
+    await selectMetric(m.id, m.features);
   };
 
-  const selectMetric = async (id: string) => {
+  const selectMetric = async (id: string, featuresOverride?: ZctaFeature[]) => {
     setSelectedMetric(id);
     const key = `${config.dataset}-${config.year}-${id}`;
-    let features = metricFeatures[key];
+    let features = featuresOverride || metricFeatures[key];
     if (!features) {
       const varId = id.includes('_') ? id : id + '_001E';
       features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -25,6 +25,9 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
           <Link href={linkHref} className="text-blue-600 underline text-sm">
             {linkText}
           </Link>
+          <Link href="/stats" className="text-blue-600 underline text-sm">
+            Stat Management
+          </Link>
           <Link href="/logs" className="text-blue-600 underline text-sm">
             Logs
           </Link>

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -25,6 +25,18 @@ const _schema = i.schema({
       longitude: i.number(),
       isPrimary: i.boolean(),
     }),
+    stats: i.entity({
+      variable: i.string().indexed(),
+      title: i.string(),
+      description: i.string(),
+      category: i.string(),
+      dataset: i.string(),
+      year: i.number(),
+    }),
+    statValues: i.entity({
+      zcta: i.string(),
+      value: i.number().optional(),
+    }),
   },
   links: {
     orgLocations: {
@@ -38,6 +50,10 @@ const _schema = i.schema({
     orgPhotos: {
       forward: { on: 'organizations', has: 'many', label: 'photos' },
       reverse: { on: '$files', has: 'one', label: 'photoOrg' },
+    },
+    statData: {
+      forward: { on: 'stats', has: 'many', label: 'values' },
+      reverse: { on: 'statValues', has: 'one', label: 'stat' },
     },
   },
 });

--- a/lib/census.ts
+++ b/lib/census.ts
@@ -121,3 +121,20 @@ export async function fetchZctaMetric(
   metricCache.set(cacheKey, features);
   return features;
 }
+
+export async function featuresFromStatValues(
+  values: Array<{ zcta: string; value: number | null }>,
+): Promise<ZctaFeature[]> {
+  const map = new Map(values.map(v => [v.zcta, v.value]));
+  const boundaries = await loadZctaBoundaries();
+  return boundaries
+    .filter(f => map.has(String(f.properties['ZCTA5CE10'])))
+    .map(f => ({
+      type: 'Feature',
+      geometry: f.geometry,
+      properties: {
+        ...f.properties,
+        value: map.get(String(f.properties['ZCTA5CE10'])) ?? null,
+      },
+    }));
+}

--- a/lib/censusTools.ts
+++ b/lib/censusTools.ts
@@ -34,6 +34,14 @@ export async function loadVariables(year: string, dataset: string) {
   return variablesCache.get(key)!;
 }
 
+export async function getVariableInfo(id: string, year: string, dataset: string) {
+  const vars = await loadVariables(year, dataset);
+  const entry = vars.find(([vid]) => vid === id);
+  if (!entry) return null;
+  const info = entry[1];
+  return { id, label: info.label, concept: info.concept };
+}
+
 export async function validateVariableId(id: string, year: string, dataset: string) {
   if (CURATED_VARIABLES.some((v) => v.id === id)) return true;
   const vars = await loadVariables(year, dataset);

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -1,0 +1,32 @@
+import { id } from '@instantdb/react';
+import db from './db';
+import { ZctaFeature } from './census';
+
+export async function saveStat(params: {
+  variable: string;
+  title: string;
+  description: string;
+  category: string;
+  dataset: string;
+  year: string;
+  features: ZctaFeature[];
+}) {
+  const statId = id();
+  const txs = [
+    db.tx.stats[statId].update({
+      variable: params.variable,
+      title: params.title,
+      description: params.description,
+      category: params.category,
+      dataset: params.dataset,
+      year: Number(params.year),
+    }),
+    ...params.features.map(f => {
+      const vid = id();
+      return db.tx.statValues[vid]
+        .update({ zcta: f.properties.ZCTA5CE10, value: f.properties.value ?? undefined })
+        .link({ stat: statId });
+    })
+  ];
+  await db.transact(txs);
+}


### PR DESCRIPTION
## Summary
- add stats and statValues to InstantDB schema
- introduce admin/user chat modes and persist stats
- create stat management page for editing and refreshing census data

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4b93c9698832d934b21ca1587dbb7