### PR TITLE
feat: add stat management and chat modes

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import adminDb from '../../../lib/adminDb';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const variable = searchParams.get('variable');
+  if (!variable) {
+    return NextResponse.json({ error: 'variable required' }, { status: 400 });
+  }
+
+  const { stats } = await adminDb.query({
+    stats: {
+      where: { variable },
+      values: {},
+    },
+  });
+
+  const stat = (stats || [])[0];
+  if (!stat) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ stat: { ...stat, values: undefined }, values: stat.values });
+}

--- a/app/api/user-chat/route.ts
+++ b/app/api/user-chat/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import adminDb from '../../../lib/adminDb';
+import { callOpenRouter } from '../../../lib/openRouter';
+import { Stat } from '../../../types/stat';
+
+interface Message {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  tool_call_id?: string;
+}
+
+async function searchStats(query: string) {
+  const q = query.toLowerCase();
+  const res = (await adminDb.query({
+    stats: {
+      where: {
+        or: [
+          { title: { $ilike: `%${q}%` } },
+          { description: { $ilike: `%${q}%` } },
+        ],
+      },
+    },
+  })) as { stats: Stat[] };
+  const list = res.stats || [];
+  return list.map((s) => ({ id: s.variable, label: s.title, concept: s.category }));
+}
+
+export async function POST(req: NextRequest) {
+  const { messages } = await req.json();
+
+  const tools = [
+    {
+      type: 'function',
+      function: {
+        name: 'search_stats',
+        description: 'Search stored statistics matching a query.',
+        parameters: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Search term for the desired statistic' },
+          },
+          required: ['query'],
+        },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'add_metric',
+        description: 'Add a stored statistic to the user\'s metric selection dropdown.',
+        parameters: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', description: 'Variable identifier' },
+            label: { type: 'string', description: 'Human readable label' },
+          },
+          required: ['id', 'label'],
+        },
+      },
+    },
+  ];
+
+  const convo: Message[] = [...messages];
+  const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+
+  while (true) {
+    const response = await callOpenRouter({
+      model: 'openai/gpt-5-mini',
+      messages: convo,
+      tools,
+      tool_choice: 'auto',
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+    });
+
+    const message = response.choices?.[0]?.message;
+    const toolCalls = message?.tool_calls ?? [];
+    convo.push(message as Message);
+
+    if (!toolCalls.length) {
+      return NextResponse.json({ message, toolInvocations });
+    }
+
+    for (const call of toolCalls) {
+      const name = call.function.name;
+      const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
+      let result: unknown;
+      if (name === 'search_stats') {
+        result = await searchStats(args.query as string);
+      } else if (name === 'add_metric') {
+        toolInvocations.push({ name, args });
+        result = { ok: true };
+      }
+      convo.push({
+        role: 'tool',
+        content: JSON.stringify(result),
+        tool_call_id: call.id,
+      });
+    }
+  }
+}

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import TopNav from '../../components/TopNav';
+import db from '../../lib/db';
+import { id } from '@instantdb/react';
+import { fetchZctaMetric } from '../../lib/census';
+import { Stat, StatValue } from '../../types/stat';
+
+export default function StatsPage() {
+  const { data, isLoading, error } = db.useQuery<{ stats: Stat[] }>({
+    stats: { values: {} },
+  });
+
+  const handleDescChange = async (statId: string, desc: string) => {
+    await db.transact([db.tx.stats[statId].update({ description: desc })]);
+  };
+
+  const handleDelete = async (stat: Stat) => {
+    await db.transact([
+      db.tx.stats[stat.id].delete(),
+      ...(stat.values || []).map((v: StatValue) => db.tx.statValues[v.id].delete()),
+    ]);
+  };
+
+  const handleRefresh = async (stat: Stat) => {
+    const features = await fetchZctaMetric(stat.variable, { dataset: stat.dataset, year: stat.year });
+    await db.transact([
+      ...(stat.values || []).map((v: StatValue) => db.tx.statValues[v.id].delete()),
+      ...features.map((f) =>
+        db.tx.statValues[id()]
+          .update({ zcta: f.properties.ZCTA5CE10, value: f.properties.value ?? undefined })
+          .link({ stat: stat.id })
+      ),
+      db.tx.stats[stat.id].update({ updatedAt: Date.now() }),
+    ]);
+  };
+
+  if (isLoading) return <div className="p-4">Loading stats...</div>;
+  if (error) return <div className="p-4 text-red-500">Error loading stats: {error.message}</div>;
+
+  const stats = data?.stats || [];
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      <TopNav linkHref="/" linkText="Map" />
+      <main className="flex-1 max-w-5xl mx-auto p-4 w-full overflow-x-auto">
+        <h2 className="text-xl mb-4">Stat Management</h2>
+        <table className="min-w-full text-sm border">
+          <thead>
+            <tr>
+              <th className="border px-2 py-1 text-left">Title</th>
+              <th className="border px-2 py-1 text-left">Description</th>
+              <th className="border px-2 py-1 text-left">Category</th>
+              <th className="border px-2 py-1 text-left">Dataset</th>
+              <th className="border px-2 py-1 text-left">Year</th>
+              <th className="border px-2 py-1 text-left">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.map((s: Stat) => (
+              <tr key={s.id}>
+                <td className="border px-2 py-1">{s.title}</td>
+                <td className="border px-2 py-1">
+                  <input
+                    value={s.description || ''}
+                    onChange={(e) => handleDescChange(s.id, e.target.value)}
+                    className="w-full border px-1 py-0.5"
+                  />
+                </td>
+                <td className="border px-2 py-1">{s.category}</td>
+                <td className="border px-2 py-1">{s.dataset}</td>
+                <td className="border px-2 py-1">{s.year}</td>
+                <td className="border px-2 py-1 space-x-2">
+                  <button className="text-blue-600 underline" onClick={() => handleRefresh(s)}>
+                    Refresh
+                  </button>
+                  <button className="text-red-600 underline" onClick={() => handleDelete(s)}>
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </main>
+    </div>
+  );
+}

--- a/components/MetricContext.tsx
+++ b/components/MetricContext.tsx
@@ -1,8 +1,16 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect } from 'react';
-import { fetchZctaMetric, type ZctaFeature, prefetchZctaBoundaries } from '../lib/census';
+import {
+  fetchZctaMetric,
+  type ZctaFeature,
+  prefetchZctaBoundaries,
+  getZctaBoundaries,
+} from '../lib/census';
 import { useConfig } from './ConfigContext';
+import db from '../lib/db';
+import { id as genId } from '@instantdb/react';
+import { loadVariables } from '../lib/censusTools';
 
 interface Metric {
   id: string;
@@ -14,7 +22,7 @@ interface MetricsContextValue {
   selectedMetric: string | null;
   zctaFeatures: ZctaFeature[] | undefined;
   addMetric: (metric: Metric) => Promise<void>;
-  selectMetric: (id: string) => Promise<void>;
+  selectMetric: (id: string, label?: string) => Promise<void>;
 }
 
 const MetricsContext = createContext<MetricsContextValue | undefined>(undefined);
@@ -31,18 +39,79 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const addMetric = async (m: Metric) => {
-    setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
-    await selectMetric(m.id);
+    setMetrics((prev) => (prev.find((p) => p.id === m.id) ? prev : [...prev, m]));
+    await selectMetric(m.id, m.label);
   };
 
-  const selectMetric = async (id: string) => {
+  async function fetchFromDb(variable: string): Promise<ZctaFeature[] | null> {
+    try {
+      const res = await fetch(`/api/stats?variable=${variable}`);
+      if (!res.ok) return null;
+      const data = await res.json();
+      const boundaries = await getZctaBoundaries();
+      const valueMap = new Map(
+        (data.values as Array<{ zcta: string; value: number | null }>).map((v) => [v.zcta, v.value])
+      );
+      return boundaries
+        .filter((b) => valueMap.has(b.properties.ZCTA5CE10))
+        .map((b) => ({
+          type: 'Feature',
+          geometry: b.geometry,
+          properties: {
+            ...b.properties,
+            value: valueMap.get(b.properties.ZCTA5CE10) ?? null,
+          },
+        }));
+    } catch {
+      return null;
+    }
+  }
+
+  async function saveMetricToDb(variable: string, label: string, features: ZctaFeature[]) {
+    try {
+      const vars = await loadVariables(config.year, config.dataset);
+      const info = vars.find(([vid]) => vid === variable);
+      const concept = info ? info[1].concept : '';
+      const statId = genId();
+      await db.transact([
+        db.tx.stats[statId].update({
+          variable,
+          title: label,
+          description: label,
+          category: concept,
+          dataset: config.dataset,
+          year: config.year,
+          source: 'US Census',
+          updatedAt: Date.now(),
+        }),
+        ...features.map((f) =>
+          db.tx.statValues[genId()]
+            .update({
+              zcta: f.properties.ZCTA5CE10,
+              value: f.properties.value ?? undefined,
+            })
+            .link({ stat: statId })
+        ),
+      ]);
+    } catch (err) {
+      console.error('Failed to save metric', err);
+    }
+  }
+
+  const selectMetric = async (id: string, label?: string) => {
     setSelectedMetric(id);
-    const key = `${config.dataset}-${config.year}-${id}`;
+    const key = `${id}`;
     let features = metricFeatures[key];
     if (!features) {
-      const varId = id.includes('_') ? id : id + '_001E';
-      features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
-      setMetricFeatures(prev => ({ ...prev, [key]: features! }));
+      features = await fetchFromDb(id);
+      if (!features) {
+        const varId = id.includes('_') ? id : id + '_001E';
+        features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
+        if (label) {
+          await saveMetricToDb(varId, label, features);
+        }
+      }
+      setMetricFeatures((prev) => ({ ...prev, [key]: features! }));
     }
     setZctaFeatures(features);
   };

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -25,6 +25,9 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
           <Link href={linkHref} className="text-blue-600 underline text-sm">
             {linkText}
           </Link>
+          <Link href="/stats" className="text-blue-600 underline text-sm">
+            Stat Management
+          </Link>
           <Link href="/logs" className="text-blue-600 underline text-sm">
             Logs
           </Link>

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -25,6 +25,20 @@ const _schema = i.schema({
       longitude: i.number(),
       isPrimary: i.boolean(),
     }),
+    stats: i.entity({
+      variable: i.string().unique().indexed(),
+      title: i.string(),
+      description: i.string(),
+      category: i.string(),
+      dataset: i.string(),
+      year: i.string(),
+      source: i.string(),
+      updatedAt: i.number().indexed(),
+    }),
+    statValues: i.entity({
+      zcta: i.string().indexed(),
+      value: i.number().optional(),
+    }),
   },
   links: {
     orgLocations: {
@@ -38,6 +52,10 @@ const _schema = i.schema({
     orgPhotos: {
       forward: { on: 'organizations', has: 'many', label: 'photos' },
       reverse: { on: '$files', has: 'one', label: 'photoOrg' },
+    },
+    statZctaValues: {
+      forward: { on: 'stats', has: 'many', label: 'values' },
+      reverse: { on: 'statValues', has: 'one', label: 'stat' },
     },
   },
 });

--- a/lib/adminDb.ts
+++ b/lib/adminDb.ts
@@ -1,0 +1,9 @@
+import { init } from '@instantdb/admin';
+import schema from '../instant.schema';
+
+const APP_ID = process.env.NEXT_PUBLIC_INSTANT_APP_ID!;
+const ADMIN_TOKEN = process.env.INSTANT_ADMIN_TOKEN!;
+
+const db = init({ appId: APP_ID, adminToken: ADMIN_TOKEN, schema });
+
+export default db;

--- a/lib/census.ts
+++ b/lib/census.ts
@@ -63,6 +63,10 @@ export function prefetchZctaBoundaries() {
   loadZctaBoundaries().catch(() => {});
 }
 
+export async function getZctaBoundaries() {
+  return loadZctaBoundaries();
+}
+
 interface MetricOptions {
   year?: string;
   dataset?: string;

--- a/types/stat.ts
+++ b/types/stat.ts
@@ -1,0 +1,18 @@
+export interface StatValue {
+  id: string;
+  zcta: string;
+  value: number | null;
+}
+
+export interface Stat {
+  id: string;
+  variable: string;
+  title: string;
+  description: string;
+  category: string;
+  dataset: string;
+  year: string;
+  source: string;
+  updatedAt: number;
+  values?: StatValue[];
+}


### PR DESCRIPTION
## Summary
- add toggleable user/admin chat modes with InstantDB-backed user mode
- persist fetched census metrics in InstantDB and expose stat management UI
- extend schema and API to support stored stat retrieval and LLM search

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4b93c9698832d934b21ca1587dbb7