### PR TITLE
Add chat modes and stat management

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import TopNav from '../../components/TopNav';
+import db from '../../lib/db';
+import { fetchZctaMetric, type ZctaFeature } from '../../lib/census';
+import type { Stat } from '../../types/stat';
+
+export default function StatsPage() {
+  const { data, isLoading, error } = db.useQuery({ stats: {} });
+
+  const handleEdit = async (stat: Stat) => {
+    const desc = prompt('Edit description', stat.description);
+    if (desc !== null) {
+      await db.transact([db.tx.stats[stat.id].update({ description: desc })]);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    await db.transact([db.tx.stats[id].delete()]);
+  };
+
+  const handleRefresh = async (stat: Stat) => {
+    const varId = stat.variableId.includes('_') ? stat.variableId : stat.variableId + '_001E';
+    const features = await fetchZctaMetric(varId, { year: String(stat.year), dataset: stat.dataset });
+    const zctaMap: Record<string, number | null> = {};
+    features?.forEach((f: ZctaFeature) => {
+      zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+    });
+    await db.transact([db.tx.stats[stat.id].update({ data: JSON.stringify(zctaMap) })]);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      <TopNav linkHref="/" linkText="Map" />
+      <main className="flex-1 max-w-4xl mx-auto p-4 w-full overflow-x-auto">
+        <h2 className="text-xl mb-4">Stat Management</h2>
+        {isLoading && <div>Loading stats...</div>}
+        {error && <div className="text-red-500">Error loading stats: {error.message}</div>}
+        {data && (
+          <table className="min-w-full text-sm border">
+            <thead>
+              <tr>
+                <th className="border px-2 py-1 text-left">Title</th>
+                <th className="border px-2 py-1 text-left">Description</th>
+                <th className="border px-2 py-1 text-left">Category</th>
+                <th className="border px-2 py-1 text-left">Dataset</th>
+                <th className="border px-2 py-1 text-left">Source</th>
+                <th className="border px-2 py-1 text-left">Year</th>
+                <th className="border px-2 py-1 text-left">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.stats?.map((stat: Stat) => (
+                <tr key={stat.id}>
+                  <td className="border px-2 py-1">{stat.title}</td>
+                  <td className="border px-2 py-1">{stat.description}</td>
+                  <td className="border px-2 py-1">{stat.category}</td>
+                  <td className="border px-2 py-1">{stat.dataset}</td>
+                  <td className="border px-2 py-1">{stat.source}</td>
+                  <td className="border px-2 py-1">{stat.year}</td>
+                  <td className="border px-2 py-1 space-x-2">
+                    <button className="text-blue-600 underline" onClick={() => handleEdit(stat)}>Edit</button>
+                    <button className="text-red-600 underline" onClick={() => handleDelete(stat.id)}>Delete</button>
+                    <button className="text-green-600 underline" onClick={() => handleRefresh(stat)}>Refresh</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import db from '../lib/db';
 import { useConfig } from './ConfigContext';
 import ConfigControls from './ConfigControls';
+import type { Stat } from '../types/stat';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
@@ -17,41 +19,73 @@ export default function CensusChat({ onAddMetric }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [mode, setMode] = useState<'user' | 'admin'>('user');
   const { config } = useConfig();
+  const { data: statData } = db.useQuery({ stats: {} });
 
-  const sendMessage = async () => {
-    if (!input.trim()) return;
-    const newMessages = [...messages, { role: 'user' as const, content: input }];
-    setMessages(newMessages);
-    setInput('');
-    setLoading(true);
+    const sendMessage = async () => {
+      if (!input.trim()) return;
+      const newMessages = [...messages, { role: 'user' as const, content: input }];
+      setMessages(newMessages);
+      setInput('');
 
-    const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
-        config,
-      }),
-    });
-    const data = await res.json();
-    setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
-    setLoading(false);
+      if (mode === 'admin') {
+        setLoading(true);
+        const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
+        const res = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
+            config,
+          }),
+        });
+        const data = await res.json();
+        setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
+        setLoading(false);
 
-    if (data.toolInvocations) {
-      for (const inv of data.toolInvocations) {
-        if (inv.name === 'add_metric') {
-          await onAddMetric(inv.args);
+        if (data.toolInvocations) {
+          for (const inv of data.toolInvocations) {
+            if (inv.name === 'add_metric') {
+              await onAddMetric(inv.args);
+            }
+          }
+        }
+      } else {
+      const stats = (statData?.stats || []).filter((s): s is Stat => Boolean(s));
+      const query = input.trim().toLowerCase();
+      const match = stats.find((s) => {
+        const title = s.title?.toLowerCase() || '';
+        const variableId = s.variableId?.toLowerCase();
+        return title.includes(query) || variableId === query;
+      });
+        if (match) {
+        const zctaMap: Record<string, number | null> = JSON.parse(match.data);
+        const lines = Object.entries(zctaMap)
+            .map(([z, v]) => `${z}: ${v}`)
+            .join(', ');
+          const reply = `${match.title} (${match.year} ${match.dataset}) - ${lines}`;
+          setMessages([...newMessages, { role: 'assistant', content: reply }]);
+        } else {
+          setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
         }
       }
-    }
-  };
+    };
 
-  return (
-    <div className="flex flex-col h-full bg-white text-gray-900">
-      <ConfigControls />
-      <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
+    return (
+      <div className="flex flex-col h-full bg-white text-gray-900">
+        <div className="flex justify-end mb-2">
+          <select
+            className="border border-gray-300 rounded p-1 text-sm"
+            value={mode}
+            onChange={e => setMode(e.target.value as 'user' | 'admin')}
+          >
+            <option value="user">User Mode</option>
+            <option value="admin">Admin Mode</option>
+          </select>
+        </div>
+        {mode === 'admin' && <ConfigControls />}
+        <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
         {messages.map((m, idx) => (
           <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
             <span
@@ -63,22 +97,22 @@ export default function CensusChat({ onAddMetric }: CensusChatProps) {
         ))}
         {loading && <div className="text-sm text-gray-500">Thinking...</div>}
       </div>
-      <div className="flex">
-        <input
-          className="flex-1 bg-white border border-gray-300 rounded-l p-2 text-gray-900"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
-          placeholder="Ask about US Census stats..."
-        />
-        <button
-          className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"
-          onClick={sendMessage}
-          disabled={loading}
-        >
-          Send
-        </button>
+        <div className="flex">
+          <input
+            className="flex-1 bg-white border border-gray-300 rounded-l p-2 text-gray-900"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+            placeholder={mode === 'admin' ? 'Ask about US Census stats...' : 'Search stored stats...'}
+          />
+          <button
+            className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"
+            onClick={sendMessage}
+            disabled={loading && mode === 'admin'}
+          >
+            Send
+          </button>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -25,6 +25,9 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
           <Link href={linkHref} className="text-blue-600 underline text-sm">
             {linkText}
           </Link>
+          <Link href="/stats" className="text-blue-600 underline text-sm">
+            Stat Management
+          </Link>
           <Link href="/logs" className="text-blue-600 underline text-sm">
             Logs
           </Link>

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -25,6 +25,16 @@ const _schema = i.schema({
       longitude: i.number(),
       isPrimary: i.boolean(),
     }),
+    stats: i.entity({
+      variableId: i.string().unique().indexed(),
+      title: i.string(),
+      description: i.string(),
+      category: i.string(),
+      dataset: i.string(),
+      source: i.string(),
+      year: i.number(),
+      data: i.string(),
+    }),
   },
   links: {
     orgLocations: {

--- a/types/stat.ts
+++ b/types/stat.ts
@@ -1,0 +1,11 @@
+export interface Stat {
+  id: string;
+  variableId: string;
+  title: string;
+  description: string;
+  category: string;
+  dataset: string;
+  source: string;
+  year: number;
+  data: string;
+}


### PR DESCRIPTION
## Summary
- add user/admin toggle for chat to switch between local stats and Census queries
- persist added Census stats with ZCTA data in InstantDB
- introduce Stat Management page and navbar link to edit, refresh or delete stats
- fix user mode stat lookup when stats are missing fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b93c9698832d934b21ca1587dbb7