### PR TITLE
Add chat modes and stat management

### DIFF
--- a/app/api/user-chat/route.ts
+++ b/app/api/user-chat/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { callOpenRouter } from '../../../lib/openRouter';
+import { init } from '@instantdb/admin';
+import type { Stat } from '../../../types/stat';
+
+const APP_ID = process.env.NEXT_PUBLIC_INSTANT_APP_ID!;
+const ADMIN_TOKEN = process.env.INSTANT_ADMIN_TOKEN!;
+const db = init({ appId: APP_ID, adminToken: ADMIN_TOKEN });
+
+interface Message {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  tool_call_id?: string;
+}
+
+export async function POST(req: NextRequest) {
+  const { messages } = await req.json();
+
+  const tools = [
+    {
+      type: 'function',
+      function: {
+        name: 'search_stats',
+        description: 'Search stored stats by code or description.',
+        parameters: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Search term' },
+          },
+          required: ['query'],
+        },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'add_stat_to_map',
+        description: 'Add a stored stat to the map using its variable id.',
+        parameters: {
+          type: 'object',
+          properties: {
+            variableId: { type: 'string', description: 'Stat variable id' },
+          },
+          required: ['variableId'],
+        },
+      },
+    },
+  ];
+
+  const convo: Message[] = [...messages];
+  const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+
+  while (true) {
+    const response = await callOpenRouter({
+      model: 'openai/gpt-5-nano',
+      messages: convo,
+      tools,
+      tool_choice: 'auto',
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+    });
+
+    const message = response.choices?.[0]?.message;
+    const toolCalls = message?.tool_calls ?? [];
+    convo.push(message as Message);
+
+    if (!toolCalls.length) {
+      return NextResponse.json({ message, toolInvocations });
+    }
+
+    for (const call of toolCalls) {
+      const name = call.function.name;
+      const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
+      let result: unknown;
+      if (name === 'search_stats') {
+        const q = String(args.query || '');
+        const queryRes = await db.query({
+          stats: {
+            $: {
+              where: {
+                or: [
+                  { variableId: { $ilike: `%${q}%` } },
+                  { title: { $ilike: `%${q}%` } },
+                  { description: { $ilike: `%${q}%` } },
+                ],
+              },
+            },
+          },
+        });
+        const stats = (queryRes.stats as Stat[] | undefined) || [];
+        result = stats.map((s) => ({
+          variableId: s.variableId,
+          description: s.description,
+        }));
+      } else if (name === 'add_stat_to_map') {
+        const variableId = String(args.variableId || '');
+        const queryRes = await db.query({
+          stats: { $: { where: { variableId } } },
+        });
+        const stat = (queryRes.stats as Stat[] | undefined)?.[0];
+        if (stat) {
+          result = { ok: true };
+          toolInvocations.push({ name: 'add_stat', args: { id: stat.variableId, label: stat.description } });
+        } else {
+          result = { ok: false, error: 'Stat not found' };
+        }
+      }
+      convo.push({ role: 'tool', content: JSON.stringify(result), tool_call_id: call.id });
+    }
+  }
+}

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import TopNav from '../../components/TopNav';
+import db from '../../lib/db';
+import { fetchZctaMetric, type ZctaFeature } from '../../lib/census';
+import type { Stat } from '../../types/stat';
+
+export default function StatsPage() {
+  const { data, isLoading, error } = db.useQuery({ stats: {} });
+
+  const handleEdit = async (stat: Stat) => {
+    const desc = prompt('Edit description', stat.description);
+    if (desc !== null) {
+      await db.transact([db.tx.stats[stat.id].update({ description: desc })]);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    await db.transact([db.tx.stats[id].delete()]);
+  };
+
+  const handleRefresh = async (stat: Stat) => {
+    const varId = stat.variableId.includes('_') ? stat.variableId : stat.variableId + '_001E';
+    const features = await fetchZctaMetric(varId, { year: String(stat.year), dataset: stat.dataset });
+    const zctaMap: Record<string, number | null> = {};
+    features?.forEach((f: ZctaFeature) => {
+      zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+    });
+    await db.transact([db.tx.stats[stat.id].update({ data: JSON.stringify(zctaMap) })]);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      <TopNav linkHref="/" linkText="Map" />
+      <main className="flex-1 max-w-4xl mx-auto p-4 w-full overflow-x-auto">
+        <h2 className="text-xl mb-4">Stat Management</h2>
+        {isLoading && <div>Loading stats...</div>}
+        {error && <div className="text-red-500">Error loading stats: {error.message}</div>}
+        {data && (
+          <table className="min-w-full text-sm border">
+            <thead>
+              <tr>
+                <th className="border px-2 py-1 text-left">Code</th>
+                <th className="border px-2 py-1 text-left">Description</th>
+                <th className="border px-2 py-1 text-left">Category</th>
+                <th className="border px-2 py-1 text-left">Dataset</th>
+                <th className="border px-2 py-1 text-left">Source</th>
+                <th className="border px-2 py-1 text-left">Year</th>
+                <th className="border px-2 py-1 text-left">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.stats?.map((stat: Stat) => (
+                <tr key={stat.id}>
+                  <td className="border px-2 py-1">{stat.title}</td>
+                  <td className="border px-2 py-1">{stat.description}</td>
+                  <td className="border px-2 py-1">{stat.category}</td>
+                  <td className="border px-2 py-1">{stat.dataset}</td>
+                  <td className="border px-2 py-1">{stat.source}</td>
+                  <td className="border px-2 py-1">{stat.year}</td>
+                  <td className="border px-2 py-1 space-x-2">
+                    <button className="text-blue-600 underline" onClick={() => handleEdit(stat)}>Edit</button>
+                    <button className="text-red-600 underline" onClick={() => handleDelete(stat.id)}>Delete</button>
+                    <button className="text-green-600 underline" onClick={() => handleRefresh(stat)}>Refresh</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -17,41 +17,75 @@ export default function CensusChat({ onAddMetric }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [mode, setMode] = useState<'user' | 'admin'>('user');
   const { config } = useConfig();
 
-  const sendMessage = async () => {
-    if (!input.trim()) return;
-    const newMessages = [...messages, { role: 'user' as const, content: input }];
-    setMessages(newMessages);
-    setInput('');
-    setLoading(true);
+    const sendMessage = async () => {
+      if (!input.trim()) return;
+      const newMessages = [...messages, { role: 'user' as const, content: input }];
+      setMessages(newMessages);
+      setInput('');
 
-    const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
-        config,
-      }),
-    });
-    const data = await res.json();
-    setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
-    setLoading(false);
+      if (mode === 'admin') {
+        setLoading(true);
+        const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
+        const res = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
+            config,
+          }),
+        });
+        const data = await res.json();
+        setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
+        setLoading(false);
 
-    if (data.toolInvocations) {
-      for (const inv of data.toolInvocations) {
-        if (inv.name === 'add_metric') {
-          await onAddMetric(inv.args);
+        if (data.toolInvocations) {
+          for (const inv of data.toolInvocations) {
+            if (inv.name === 'add_metric') {
+              await onAddMetric(inv.args);
+            }
+          }
         }
+      } else {
+        setLoading(true);
+        const systemPrompt =
+          'You help users find stored statistics. Use the available tools to search stats and add them to the map. When a stat is added, reply with "Added to map!"';
+        const res = await fetch('/api/user-chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messages: [{ role: 'system', content: systemPrompt }, ...newMessages] }),
+        });
+        const data = await res.json();
+        let reply = data.message?.content || '';
+        if (data.toolInvocations) {
+          for (const inv of data.toolInvocations) {
+            if (inv.name === 'add_stat') {
+              await onAddMetric(inv.args);
+              reply = 'Added to map!';
+            }
+          }
+        }
+        setMessages([...newMessages, { role: 'assistant', content: reply }]);
+        setLoading(false);
       }
-    }
-  };
+    };
 
-  return (
-    <div className="flex flex-col h-full bg-white text-gray-900">
-      <ConfigControls />
-      <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
+    return (
+      <div className="flex flex-col h-full bg-white text-gray-900">
+        <div className="flex justify-end mb-2">
+          <select
+            className="border border-gray-300 rounded p-1 text-sm"
+            value={mode}
+            onChange={e => setMode(e.target.value as 'user' | 'admin')}
+          >
+            <option value="user">User Mode</option>
+            <option value="admin">Admin Mode</option>
+          </select>
+        </div>
+        {mode === 'admin' && <ConfigControls />}
+        <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
         {messages.map((m, idx) => (
           <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
             <span
@@ -63,22 +97,22 @@ export default function CensusChat({ onAddMetric }: CensusChatProps) {
         ))}
         {loading && <div className="text-sm text-gray-500">Thinking...</div>}
       </div>
-      <div className="flex">
-        <input
-          className="flex-1 bg-white border border-gray-300 rounded-l p-2 text-gray-900"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
-          placeholder="Ask about US Census stats..."
-        />
-        <button
-          className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"
-          onClick={sendMessage}
-          disabled={loading}
-        >
-          Send
-        </button>
+        <div className="flex">
+          <input
+            className="flex-1 bg-white border border-gray-300 rounded-l p-2 text-gray-900"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+            placeholder={mode === 'admin' ? 'Ask about US Census stats...' : 'Ask about stored stats...'}
+          />
+          <button
+            className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"
+            onClick={sendMessage}
+            disabled={loading}
+          >
+            Send
+          </button>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }

--- a/components/MetricContext.tsx
+++ b/components/MetricContext.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect } from 'react';
-import { fetchZctaMetric, type ZctaFeature, prefetchZctaBoundaries } from '../lib/census';
+import { id } from '@instantdb/react';
+import db from '../lib/db';
+import { fetchZctaMetric, type ZctaFeature, prefetchZctaBoundaries, zctaMapToFeatures } from '../lib/census';
 import { useConfig } from './ConfigContext';
+import type { Stat } from '../types/stat';
 
 interface Metric {
   id: string;
@@ -12,9 +15,9 @@ interface Metric {
 interface MetricsContextValue {
   metrics: Metric[];
   selectedMetric: string | null;
-  zctaFeatures: ZctaFeature[] | undefined;
-  addMetric: (metric: Metric) => Promise<void>;
-  selectMetric: (id: string) => Promise<void>;
+    zctaFeatures: ZctaFeature[] | undefined;
+    addMetric: (metric: Metric) => Promise<void>;
+    selectMetric: (id: string) => Promise<void>;
 }
 
 const MetricsContext = createContext<MetricsContextValue | undefined>(undefined);
@@ -25,27 +28,71 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
   const [zctaFeatures, setZctaFeatures] = useState<ZctaFeature[] | undefined>();
   const [metricFeatures, setMetricFeatures] = useState<Record<string, ZctaFeature[]>>({});
   const { config } = useConfig();
+  const { data: statData } = db.useQuery({ stats: {} });
 
   useEffect(() => {
     prefetchZctaBoundaries();
   }, []);
 
-  const addMetric = async (m: Metric) => {
-    setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
-    await selectMetric(m.id);
-  };
+    const addMetric = async (m: Metric) => {
+      setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
+      const key = `${config.dataset}-${config.year}-${m.id}`;
+      let features = metricFeatures[key];
 
-  const selectMetric = async (id: string) => {
-    setSelectedMetric(id);
-    const key = `${config.dataset}-${config.year}-${id}`;
-    let features = metricFeatures[key];
-    if (!features) {
-      const varId = id.includes('_') ? id : id + '_001E';
-      features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
-      setMetricFeatures(prev => ({ ...prev, [key]: features! }));
-    }
-    setZctaFeatures(features);
-  };
+      if (!features) {
+        const stats = (statData?.stats as Stat[] | undefined) || [];
+        const stat = stats.find(
+          (s) =>
+            s.variableId === m.id &&
+            s.dataset === config.dataset &&
+            s.year === Number(config.year),
+        );
+        if (stat) {
+          const map = JSON.parse(stat.data) as Record<string, number | null>;
+          features = await zctaMapToFeatures(map);
+        } else {
+          const varId = m.id.includes('_') ? m.id : m.id + '_001E';
+          features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
+          if (features) {
+            const statId = id();
+            const zctaMap: Record<string, number | null> = {};
+            features.forEach(f => {
+              zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+            });
+            await db.transact([
+              db.tx.stats[statId].update({
+                variableId: m.id,
+                title: m.id,
+                description: m.label,
+                category: 'General',
+                dataset: config.dataset,
+                source: 'US Census',
+                year: Number(config.year),
+                data: JSON.stringify(zctaMap),
+              }),
+            ]);
+          }
+        }
+        if (features) {
+          setMetricFeatures(prev => ({ ...prev, [key]: features! }));
+        }
+      }
+
+      setSelectedMetric(m.id);
+      setZctaFeatures(features);
+    };
+
+    const selectMetric = async (id: string) => {
+      setSelectedMetric(id);
+      const key = `${config.dataset}-${config.year}-${id}`;
+      let features = metricFeatures[key];
+      if (!features) {
+        const varId = id.includes('_') ? id : id + '_001E';
+        features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
+        setMetricFeatures(prev => ({ ...prev, [key]: features! }));
+      }
+      setZctaFeatures(features);
+    };
 
   const value: MetricsContextValue = {
     metrics,

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -25,6 +25,9 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
           <Link href={linkHref} className="text-blue-600 underline text-sm">
             {linkText}
           </Link>
+          <Link href="/stats" className="text-blue-600 underline text-sm">
+            Stat Management
+          </Link>
           <Link href="/logs" className="text-blue-600 underline text-sm">
             Logs
           </Link>

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -25,6 +25,16 @@ const _schema = i.schema({
       longitude: i.number(),
       isPrimary: i.boolean(),
     }),
+    stats: i.entity({
+      variableId: i.string().unique().indexed(),
+      title: i.string(),
+      description: i.string(),
+      category: i.string(),
+      dataset: i.string(),
+      source: i.string(),
+      year: i.number(),
+      data: i.string(),
+    }),
   },
   links: {
     orgLocations: {

--- a/lib/census.ts
+++ b/lib/census.ts
@@ -63,6 +63,22 @@ export function prefetchZctaBoundaries() {
   loadZctaBoundaries().catch(() => {});
 }
 
+export async function zctaMapToFeatures(
+  zctaMap: Record<string, number | null>,
+): Promise<ZctaFeature[]> {
+  const boundaries = await loadZctaBoundaries();
+  return boundaries
+    .filter((f) => Object.prototype.hasOwnProperty.call(zctaMap, String(f.properties['ZCTA5CE10'])))
+    .map((f) => ({
+      type: 'Feature',
+      geometry: f.geometry,
+      properties: {
+        ...f.properties,
+        value: zctaMap[String(f.properties['ZCTA5CE10'])] ?? null,
+      },
+    }));
+}
+
 interface MetricOptions {
   year?: string;
   dataset?: string;

--- a/types/stat.ts
+++ b/types/stat.ts
@@ -1,0 +1,11 @@
+export interface Stat {
+  id: string;
+  variableId: string;
+  title: string;
+  description: string;
+  category: string;
+  dataset: string;
+  source: string;
+  year: number;
+  data: string;
+}


### PR DESCRIPTION
## Summary
- let user-mode chat search InstantDB stats via gpt-5-nano tools and add them to map
- reuse saved ZCTA metrics before fetching Census data and store stats with code as title
- expose zctaMapToFeatures helper and show stat codes in management table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b93c9698832d934b21ca1587dbb7