### PR TITLE
Add chat modes and stat management

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -10,7 +10,72 @@ interface Message {
 
 
 export async function POST(req: NextRequest) {
-  const { messages, config } = await req.json();
+  const { messages, config, mode, stats } = await req.json();
+
+  if (mode === 'user') {
+    const tools = [
+      {
+        type: 'function',
+        function: {
+          name: 'select_stat',
+          description: 'Select the best matching statistic code from the provided list.',
+          parameters: {
+            type: 'object',
+            properties: {
+              code: { type: 'string', description: 'Statistic code' },
+            },
+            required: ['code'],
+          },
+        },
+      },
+    ];
+    const list = (stats || [])
+      .map((s: { code: string; description: string }) => `${s.code}: ${s.description}`)
+      .join('\n');
+    const convo: Message[] = [
+      { role: 'system', content: `You know about these stats:\n${list}` },
+      ...(messages ? messages.slice(-1) : []),
+    ];
+    const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+    while (true) {
+      const response = await callOpenRouter({
+        model: 'openai/gpt-oss-120b:nitro',
+        messages: convo,
+        tools,
+        tool_choice: 'auto',
+        reasoning: { effort: 'low' },
+        text: { verbosity: 'low' },
+        max_output_tokens: 100,
+      });
+      const message = response.choices?.[0]?.message;
+      const toolCalls = message?.tool_calls ?? [];
+      convo.push(message as Message);
+      if (!toolCalls.length) {
+        if (message && 'reasoning' in (message as Record<string, unknown>)) {
+          delete (message as Record<string, unknown>).reasoning;
+        }
+        return NextResponse.json({ message, toolInvocations });
+      }
+      for (const call of toolCalls) {
+        const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
+        const code = args.code as string;
+        const exists = (stats || []).some((s: { code: string }) => s.code === code);
+        let result: unknown;
+        if (exists) {
+          result = { ok: true };
+          toolInvocations.push({ name: 'select_stat', args: { code } });
+        } else {
+          result = { ok: false, error: 'Unknown code' };
+        }
+        convo.push({
+          role: 'tool',
+          content: JSON.stringify(result),
+          tool_call_id: call.id,
+        });
+      }
+    }
+  }
+
   const { year = '2023', dataset = 'acs/acs5' } = config || {};
 
   const tools = [
@@ -68,6 +133,9 @@ export async function POST(req: NextRequest) {
     convo.push(message as Message);
 
     if (!toolCalls.length) {
+      if (message && 'reasoning' in (message as Record<string, unknown>)) {
+        delete (message as Record<string, unknown>).reasoning;
+      }
       return NextResponse.json({
         message,
         toolInvocations,

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { addLog, getLogs } from '../../../lib/logStore';
+import { addLog, getLogs, clearLogs } from '../../../lib/logStore';
 
 export async function GET() {
   return NextResponse.json({ logs: getLogs() });
@@ -8,5 +8,10 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   const entry = await req.json();
   addLog(entry);
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE() {
+  clearLogs();
   return NextResponse.json({ ok: true });
 }

--- a/app/logs/page.tsx
+++ b/app/logs/page.tsx
@@ -25,10 +25,23 @@ export default function LogsPage() {
     return () => clearInterval(id);
   }, []);
 
+  const clearLogs = async () => {
+    await fetch('/api/logs', { method: 'DELETE' });
+    setLogs([]);
+  };
+
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
       <TopNav linkHref="/" linkText="Map" />
       <main className="flex-1 overflow-y-auto p-4 space-y-2">
+        <div className="flex justify-end mb-2">
+          <button
+            onClick={clearLogs}
+            className="px-3 py-1 bg-red-500 text-white rounded text-sm"
+          >
+            Clear logs
+          </button>
+        </div>
         {logs.map((log) => (
           <div key={log.id} className={`flex ${log.direction === 'request' ? 'justify-start' : 'justify-end'}`}>
             <div

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ const OKCMap = dynamic(() => import('../components/OKCMap'), {
 export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
-  const { zctaFeatures, addMetric } = useMetrics();
+  const { zctaFeatures, addMetric, loadStatMetric } = useMetrics();
 
   const { data, isLoading, error } = db.useQuery({
     organizations: {
@@ -83,7 +83,7 @@ export default function Home() {
       )}
 
       <div className="fixed bottom-4 right-4 w-80 h-[32rem] bg-white text-gray-900 shadow-lg p-2 border">
-        <CensusChat onAddMetric={addMetric} />
+        <CensusChat onAddMetric={addMetric} onLoadStat={loadStatMetric} />
       </div>
     </div>
   );

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import TopNav from '../../components/TopNav';
+import db from '../../lib/db';
+import { fetchZctaMetric, type ZctaFeature } from '../../lib/census';
+import type { Stat } from '../../types/stat';
+
+export default function StatsPage() {
+  const { data, isLoading, error } = db.useQuery({ stats: {} });
+
+  const handleEdit = async (stat: Stat) => {
+    const desc = prompt('Edit description', stat.description);
+    if (desc !== null) {
+      await db.transact([db.tx.stats[stat.id].update({ description: desc })]);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    await db.transact([db.tx.stats[id].delete()]);
+  };
+
+  const handleRefresh = async (stat: Stat) => {
+    const varId = stat.code.includes('_') ? stat.code : stat.code + '_001E';
+    const features = await fetchZctaMetric(varId, { year: String(stat.year), dataset: stat.dataset });
+    const zctaMap: Record<string, number | null> = {};
+    features?.forEach((f: ZctaFeature) => {
+      zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+    });
+    await db.transact([db.tx.stats[stat.id].update({ data: JSON.stringify(zctaMap) })]);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      <TopNav linkHref="/" linkText="Map" />
+      <main className="flex-1 max-w-4xl mx-auto p-4 w-full overflow-x-auto">
+        <h2 className="text-xl mb-4">Stat Management</h2>
+        {isLoading && <div>Loading stats...</div>}
+        {error && <div className="text-red-500">Error loading stats: {error.message}</div>}
+        {data && (
+          <table className="min-w-full text-sm border">
+            <thead>
+              <tr>
+                <th className="border px-2 py-1 text-left">Code</th>
+                <th className="border px-2 py-1 text-left">Description</th>
+                <th className="border px-2 py-1 text-left">Category</th>
+                <th className="border px-2 py-1 text-left">Dataset</th>
+                <th className="border px-2 py-1 text-left">Source</th>
+                <th className="border px-2 py-1 text-left">Year</th>
+                <th className="border px-2 py-1 text-left">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.stats?.map((stat: Stat) => (
+                <tr key={stat.id}>
+                  <td className="border px-2 py-1">{stat.code}</td>
+                  <td className="border px-2 py-1">{stat.description}</td>
+                  <td className="border px-2 py-1">{stat.category}</td>
+                  <td className="border px-2 py-1">{stat.dataset}</td>
+                  <td className="border px-2 py-1">{stat.source}</td>
+                  <td className="border px-2 py-1">{stat.year}</td>
+                  <td className="border px-2 py-1 space-x-2">
+                    <button className="text-blue-600 underline" onClick={() => handleEdit(stat)}>Edit</button>
+                    <button className="text-red-600 underline" onClick={() => handleDelete(stat.id)}>Delete</button>
+                    <button className="text-green-600 underline" onClick={() => handleRefresh(stat)}>Refresh</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import db from '../lib/db';
 import { useConfig } from './ConfigContext';
 import ConfigControls from './ConfigControls';
+import type { Stat } from '../types/stat';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
@@ -11,47 +13,93 @@ interface ChatMessage {
 
 interface CensusChatProps {
   onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
+  onLoadStat: (stat: Stat) => void | Promise<void>;
 }
 
-export default function CensusChat({ onAddMetric }: CensusChatProps) {
+export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [mode, setMode] = useState<'user' | 'admin'>('user');
   const { config } = useConfig();
+  const { data: statData } = db.useQuery({ stats: {} });
 
-  const sendMessage = async () => {
-    if (!input.trim()) return;
-    const newMessages = [...messages, { role: 'user' as const, content: input }];
-    setMessages(newMessages);
-    setInput('');
-    setLoading(true);
+    const sendMessage = async () => {
+      if (!input.trim()) return;
+      const userMessage = { role: 'user' as const, content: input };
+      const newMessages = [...messages, userMessage];
+      setMessages(newMessages);
+      setInput('');
 
-    const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
-    const res = await fetch('/api/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
-        config,
-      }),
-    });
-    const data = await res.json();
-    setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
-    setLoading(false);
+      if (mode === 'admin') {
+        setLoading(true);
+        const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
+        const res = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
+            config,
+          }),
+        });
+        const data = await res.json();
+        setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
+        setLoading(false);
 
-    if (data.toolInvocations) {
-      for (const inv of data.toolInvocations) {
-        if (inv.name === 'add_metric') {
-          await onAddMetric(inv.args);
+        if (data.toolInvocations) {
+          for (const inv of data.toolInvocations) {
+            if (inv.name === 'add_metric') {
+              await onAddMetric(inv.args);
+            }
+          }
+        }
+      } else {
+        setLoading(true);
+        const stats = (statData?.stats || []) as Stat[];
+        const res = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            messages: [userMessage],
+            mode: 'user',
+            stats: stats.map(s => ({ code: s.code, description: s.description })),
+          }),
+        });
+        const data = await res.json();
+        setLoading(false);
+        type ToolInvocation = { name: string; args: Record<string, unknown> };
+        const inv = (data.toolInvocations as ToolInvocation[] | undefined)?.find(
+          (i) => i.name === 'select_stat'
+        );
+        if (inv && typeof inv.args.code === 'string') {
+          const code = inv.args.code as string;
+          const stat = stats.find(s => s.code === code);
+          if (stat) {
+            await onLoadStat(stat);
+            setMessages([...newMessages, { role: 'assistant', content: 'Added to map!' }]);
+          } else {
+            setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
+          }
+        } else {
+          setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
         }
       }
-    }
-  };
+    };
 
-  return (
-    <div className="flex flex-col h-full bg-white text-gray-900">
-      <ConfigControls />
-      <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
+    return (
+      <div className="flex flex-col h-full bg-white text-gray-900">
+        <div className="flex justify-end mb-2">
+          <select
+            className="border border-gray-300 rounded p-1 text-sm"
+            value={mode}
+            onChange={e => setMode(e.target.value as 'user' | 'admin')}
+          >
+            <option value="user">User Mode</option>
+            <option value="admin">Admin Mode</option>
+          </select>
+        </div>
+        {mode === 'admin' && <ConfigControls />}
+        <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
         {messages.map((m, idx) => (
           <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
             <span
@@ -63,22 +111,22 @@ export default function CensusChat({ onAddMetric }: CensusChatProps) {
         ))}
         {loading && <div className="text-sm text-gray-500">Thinking...</div>}
       </div>
-      <div className="flex">
-        <input
-          className="flex-1 bg-white border border-gray-300 rounded-l p-2 text-gray-900"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
-          placeholder="Ask about US Census stats..."
-        />
-        <button
-          className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"
-          onClick={sendMessage}
-          disabled={loading}
-        >
-          Send
-        </button>
+        <div className="flex">
+          <input
+            className="flex-1 bg-white border border-gray-300 rounded-l p-2 text-gray-900"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+            placeholder={mode === 'admin' ? 'Ask about US Census stats...' : 'Search stored stats...'}
+          />
+          <button
+            className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"
+            onClick={sendMessage}
+            disabled={loading}
+          >
+            Send
+          </button>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }

--- a/components/MetricContext.tsx
+++ b/components/MetricContext.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect } from 'react';
-import { fetchZctaMetric, type ZctaFeature, prefetchZctaBoundaries } from '../lib/census';
+import { id } from '@instantdb/react';
+import db from '../lib/db';
+import { fetchZctaMetric, type ZctaFeature, prefetchZctaBoundaries, featuresFromZctaMap } from '../lib/census';
 import { useConfig } from './ConfigContext';
+import type { Stat } from '../types/stat';
 
 interface Metric {
   id: string;
@@ -14,6 +17,7 @@ interface MetricsContextValue {
   selectedMetric: string | null;
   zctaFeatures: ZctaFeature[] | undefined;
   addMetric: (metric: Metric) => Promise<void>;
+  loadStatMetric: (stat: Stat) => Promise<void>;
   selectMetric: (id: string) => Promise<void>;
 }
 
@@ -33,25 +37,60 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
   const addMetric = async (m: Metric) => {
     setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
     await selectMetric(m.id);
+    const varId = m.id.includes('_') ? m.id : m.id + '_001E';
+    const features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
+    if (features) {
+      const statId = id();
+      const zctaMap: Record<string, number | null> = {};
+      features.forEach(f => {
+        zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+      });
+      await db.transact([
+        db.tx.stats[statId].update({
+          code: m.id,
+          description: m.label,
+          category: 'General',
+          dataset: config.dataset,
+          source: 'US Census',
+          year: Number(config.year),
+          data: JSON.stringify(zctaMap),
+        }),
+      ]);
+    }
+  };
+
+  const loadStatMetric = async (stat: Stat) => {
+    const m = { id: stat.code, label: stat.description };
+    setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
+    const key = `${stat.dataset}-${stat.year}-${m.id}`;
+    let features = metricFeatures[key];
+    if (!features) {
+      const zctaMap: Record<string, number | null> = JSON.parse(stat.data);
+      features = await featuresFromZctaMap(zctaMap);
+      setMetricFeatures(prev => ({ ...prev, [key]: features }));
+    }
+    setSelectedMetric(m.id);
+    setZctaFeatures(features);
   };
 
   const selectMetric = async (id: string) => {
-    setSelectedMetric(id);
-    const key = `${config.dataset}-${config.year}-${id}`;
-    let features = metricFeatures[key];
-    if (!features) {
-      const varId = id.includes('_') ? id : id + '_001E';
-      features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
-      setMetricFeatures(prev => ({ ...prev, [key]: features! }));
-    }
-    setZctaFeatures(features);
-  };
+      setSelectedMetric(id);
+      const key = `${config.dataset}-${config.year}-${id}`;
+      let features = metricFeatures[key];
+      if (!features) {
+        const varId = id.includes('_') ? id : id + '_001E';
+        features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
+        setMetricFeatures(prev => ({ ...prev, [key]: features! }));
+      }
+      setZctaFeatures(features);
+    };
 
   const value: MetricsContextValue = {
     metrics,
     selectedMetric,
     zctaFeatures,
     addMetric,
+    loadStatMetric,
     selectMetric,
   };
 

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -25,6 +25,9 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
           <Link href={linkHref} className="text-blue-600 underline text-sm">
             {linkText}
           </Link>
+          <Link href="/stats" className="text-blue-600 underline text-sm">
+            Stat Management
+          </Link>
           <Link href="/logs" className="text-blue-600 underline text-sm">
             Logs
           </Link>

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -25,6 +25,15 @@ const _schema = i.schema({
       longitude: i.number(),
       isPrimary: i.boolean(),
     }),
+    stats: i.entity({
+      code: i.string().unique().indexed(),
+      description: i.string(),
+      category: i.string(),
+      dataset: i.string(),
+      source: i.string(),
+      year: i.number(),
+      data: i.string(),
+    }),
   },
   links: {
     orgLocations: {

--- a/lib/census.ts
+++ b/lib/census.ts
@@ -63,6 +63,22 @@ export function prefetchZctaBoundaries() {
   loadZctaBoundaries().catch(() => {});
 }
 
+export async function featuresFromZctaMap(
+  zctaMap: Record<string, number | null>
+): Promise<ZctaFeature[]> {
+  const boundaries = await loadZctaBoundaries();
+  return boundaries
+    .filter((f) => Object.prototype.hasOwnProperty.call(zctaMap, String(f.properties['ZCTA5CE10'])))
+    .map((f) => ({
+      type: 'Feature',
+      geometry: f.geometry,
+      properties: {
+        ...f.properties,
+        value: zctaMap[String(f.properties['ZCTA5CE10'])] ?? null,
+      },
+    }));
+}
+
 interface MetricOptions {
   year?: string;
   dataset?: string;

--- a/lib/logStore.ts
+++ b/lib/logStore.ts
@@ -16,3 +16,8 @@ export function addLog(entry: Omit<LogEntry, 'id' | 'timestamp'>) {
 export function getLogs() {
   return logs;
 }
+
+export function clearLogs() {
+  logs.length = 0;
+  nextId = 1;
+}

--- a/lib/openRouter.ts
+++ b/lib/openRouter.ts
@@ -14,6 +14,11 @@ export async function callOpenRouter(payload: Record<string, unknown>) {
     throw new Error(`OpenRouter error: ${res.status}`);
   }
   const json = await res.json();
-  addLog({ service: 'OpenRouter', direction: 'response', message: json });
+  const cleaned = JSON.parse(
+    JSON.stringify(json, (key, value) =>
+      key === 'reasoning' || key === 'reasoning_details' ? undefined : value
+    )
+  );
+  addLog({ service: 'OpenRouter', direction: 'response', message: cleaned });
   return json;
 }

--- a/types/stat.ts
+++ b/types/stat.ts
@@ -1,0 +1,10 @@
+export interface Stat {
+  id: string;
+  code: string;
+  description: string;
+  category: string;
+  dataset: string;
+  source: string;
+  year: number;
+  data: string;
+}


### PR DESCRIPTION
## Summary
- trim user-mode chat history and swap to `openai/gpt-oss-120b:nitro` for faster stat lookup
- strip reasoning details from OpenRouter logs and expose a clear button on the Logs page
- support log clearing via new API route and backend function

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b93c9698832d934b21ca1587dbb7