### PR TITLE
Persist chat and stats locally with clear controls

### DIFF
--- a/app/api/insight/route.ts
+++ b/app/api/insight/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
   const convo: Message[] = [
     {
       role: 'system',
-      content: `You are a helpful data analyst. Use the following statistics with their ZCTA values to answer questions.\n${statLines}`,
+      content: `You are a helpful data analyst. Use the following statistics with their ZCTA values to answer questions. Respond with a simple conclusion or summary, no more than three sentences, and do not use markdown or other formatting.\n${statLines}`,
     },
     ...(messages || []),
   ];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,7 +82,7 @@ export default function Home() {
         </div>
       )}
 
-      <div className="fixed bottom-4 right-4 w-80 h-[32rem] bg-white text-gray-900 shadow-lg p-2 border">
+      <div className="fixed bottom-4 right-4 w-[30rem] h-[32rem] bg-white text-gray-900 shadow-lg p-2 border">
         <CensusChat onAddMetric={addMetric} onLoadStat={loadStatMetric} />
       </div>
     </div>

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -24,7 +24,7 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
   const [mode, setMode] = useState<'user' | 'admin'>('user');
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
-  const { clearMetrics } = useMetrics();
+  const { metrics, clearMetrics } = useMetrics();
 
   const CHAT_STORAGE_KEY = 'censusChatMessages';
   const MODE_STORAGE_KEY = 'censusChatMode';
@@ -120,12 +120,15 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
             setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
           }
         } else {
+          const activeStats = stats.filter(s =>
+            metrics.some(m => m.id === s.code)
+          );
           const res = await fetch('/api/insight', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               messages: newMessages,
-              stats: stats.map(s => ({
+              stats: activeStats.map(s => ({
                 code: s.code,
                 description: s.description,
                 data: JSON.parse(s.data),

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import db from '../lib/db';
 import { useConfig } from './ConfigContext';
 import ConfigControls from './ConfigControls';
 import type { Stat } from '../types/stat';
+import { useMetrics } from './MetricContext';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
@@ -23,6 +24,39 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
   const [mode, setMode] = useState<'user' | 'admin'>('user');
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
+  const { clearMetrics } = useMetrics();
+
+  const CHAT_STORAGE_KEY = 'censusChatMessages';
+  const MODE_STORAGE_KEY = 'censusChatMode';
+
+  useEffect(() => {
+    const stored = localStorage.getItem(CHAT_STORAGE_KEY);
+    if (stored) {
+      try {
+        setMessages(JSON.parse(stored));
+      } catch {
+        /* ignore */
+      }
+    }
+    const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
+    if (storedMode === 'user' || storedMode === 'admin') {
+      setMode(storedMode);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(messages));
+  }, [messages]);
+
+  useEffect(() => {
+    localStorage.setItem(MODE_STORAGE_KEY, mode);
+  }, [mode]);
+
+  const clearChat = () => {
+    setMessages([]);
+    localStorage.removeItem(CHAT_STORAGE_KEY);
+    clearMetrics();
+  };
 
     const sendMessage = async () => {
       if (!input.trim()) return;
@@ -107,7 +141,14 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
 
     return (
       <div className="flex flex-col h-full bg-white text-gray-900">
-        <div className="flex justify-end mb-2">
+        <div className="flex justify-end mb-2 gap-2">
+          <button
+            onClick={clearChat}
+            className="px-2 py-1 border rounded text-xs text-gray-600"
+            aria-label="Clear chat"
+          >
+            Clear
+          </button>
           <select
             className="border border-gray-300 rounded p-1 text-sm"
             value={mode}

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -12,7 +12,7 @@ interface TopNavProps {
 }
 
 export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNavProps) {
-  const { metrics, selectedMetric, selectMetric } = useMetrics();
+  const { metrics, selectedMetric, selectMetric, clearMetrics } = useMetrics();
 
   return (
     <header className="bg-white shadow-sm border-b">
@@ -32,7 +32,16 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
             Logs
           </Link>
           {metrics.length > 0 && (
-            <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
+            <div className="flex items-center gap-1">
+              <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
+              <button
+                onClick={clearMetrics}
+                className="px-2 py-1 border rounded text-sm text-gray-600"
+                aria-label="Clear active stats"
+              >
+                ×
+              </button>
+            </div>
           )}
           {onAddOrganization && (
             <CircularAddButton onClick={onAddOrganization} />


### PR DESCRIPTION
## Summary
- make chat panel wider and add clear button
- persist chat messages and active stats in localStorage
- add controls to clear chat and active stats
- tighten insight responses to brief plain summaries

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed823ba0832db4bcdcab1382678f