### PR TITLE
feat: persist chat and stats with clear controls

### DIFF
--- a/app/api/insight/route.ts
+++ b/app/api/insight/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
   const convo: Message[] = [
     {
       role: 'system',
-      content: `You are a helpful data analyst. Use the following statistics with their ZCTA values to answer questions.\n${statLines}`,
+      content: `You are a helpful data analyst. Use the following statistics with their ZCTA values to answer questions. Provide a simple conclusion or summary in no more than three sentences. Use plain text only with no markdown or special formatting.\n${statLines}`,
     },
     ...(messages || []),
   ];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,7 +82,7 @@ export default function Home() {
         </div>
       )}
 
-      <div className="fixed bottom-4 right-4 w-80 h-[32rem] bg-white text-gray-900 shadow-lg p-2 border">
+      <div className="fixed bottom-4 right-4 w-[30rem] h-[32rem] bg-white text-gray-900 shadow-lg p-2 border">
         <CensusChat onAddMetric={addMetric} onLoadStat={loadStatMetric} />
       </div>
     </div>

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import db from '../lib/db';
 import { useConfig } from './ConfigContext';
 import ConfigControls from './ConfigControls';
@@ -23,6 +23,28 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
   const [mode, setMode] = useState<'user' | 'admin'>('user');
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
+
+  useEffect(() => {
+    const stored = localStorage.getItem('censusChat');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as { messages?: ChatMessage[]; mode?: 'user' | 'admin' };
+        if (parsed.messages) setMessages(parsed.messages);
+        if (parsed.mode) setMode(parsed.mode);
+      } catch {
+        // ignore
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('censusChat', JSON.stringify({ messages, mode }));
+  }, [messages, mode]);
+
+  const clearChat = () => {
+    setMessages([]);
+    localStorage.removeItem('censusChat');
+  };
 
     const sendMessage = async () => {
       if (!input.trim()) return;
@@ -107,7 +129,13 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
 
     return (
       <div className="flex flex-col h-full bg-white text-gray-900">
-        <div className="flex justify-end mb-2">
+        <div className="flex justify-end items-center mb-2 space-x-2">
+          <button
+            onClick={clearChat}
+            className="text-xs text-gray-500 hover:text-gray-700"
+          >
+            clear
+          </button>
           <select
             className="border border-gray-300 rounded p-1 text-sm"
             value={mode}

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -12,7 +12,7 @@ interface TopNavProps {
 }
 
 export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNavProps) {
-  const { metrics, selectedMetric, selectMetric } = useMetrics();
+  const { metrics, selectedMetric, selectMetric, clearMetrics } = useMetrics();
 
   return (
     <header className="bg-white shadow-sm border-b">
@@ -32,7 +32,16 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
             Logs
           </Link>
           {metrics.length > 0 && (
-            <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
+            <div className="flex items-center gap-1">
+              <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
+              <button
+                onClick={clearMetrics}
+                className="text-gray-500 text-sm hover:text-gray-700"
+                aria-label="Clear metrics"
+              >
+                ×
+              </button>
+            </div>
           )}
           {onAddOrganization && (
             <CircularAddButton onClick={onAddOrganization} />


### PR DESCRIPTION
## Summary
- widen chat panel and add clear button with persistent session storage
- persist active map stats with local clearing control
- streamline insight responses to simple plain-text summaries

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed823ba0832db4bcdcab1382678f