### PR TITLE
Persist chat and metrics with clear controls

### DIFF
--- a/app/api/insight/route.ts
+++ b/app/api/insight/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
   const convo: Message[] = [
     {
       role: 'system',
-      content: `You are a helpful data analyst. Use the following statistics with their ZCTA values to answer questions.\n${statLines}`,
+      content: `You are a helpful data analyst. Use the following statistics with their ZCTA values to answer questions. Return a simple conclusion or summary in no more than three sentences using plain text without markdown or formatting.\n${statLines}`,
     },
     ...(messages || []),
   ];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,7 +82,7 @@ export default function Home() {
         </div>
       )}
 
-      <div className="fixed bottom-4 right-4 w-80 h-[32rem] bg-white text-gray-900 shadow-lg p-2 border">
+      <div className="fixed bottom-4 right-4 w-[30rem] h-[32rem] bg-white text-gray-900 shadow-lg p-2 border">
         <CensusChat onAddMetric={addMetric} onLoadStat={loadStatMetric} />
       </div>
     </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -12,7 +12,7 @@ interface TopNavProps {
 }
 
 export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNavProps) {
-  const { metrics, selectedMetric, selectMetric } = useMetrics();
+  const { metrics, selectedMetric, selectMetric, clearMetrics } = useMetrics();
 
   return (
     <header className="bg-white shadow-sm border-b">
@@ -32,7 +32,16 @@ export default function TopNav({ linkHref, linkText, onAddOrganization }: TopNav
             Logs
           </Link>
           {metrics.length > 0 && (
-            <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
+            <div className="flex items-center gap-1">
+              <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
+              <button
+                onClick={clearMetrics}
+                className="text-gray-500 hover:text-gray-700 text-lg leading-none"
+                aria-label="Clear metrics"
+              >
+                ×
+              </button>
+            </div>
           )}
           {onAddOrganization && (
             <CircularAddButton onClick={onAddOrganization} />


### PR DESCRIPTION
## Summary
- widen chat panel to 480px and add a top-right clear button
- persist chat history, mode, and active metrics in local storage with ability to clear
- add metric-clearing button in top nav and limit insight responses to short plain text summaries

## Testing
- `npm run lint`
- `npm run build` *(fails: process interrupted while creating production build)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ed823ba0832db4bcdcab1382678f