### PR TITLE
feat: add fast admin chat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@
 - Populated from map click events
 
 ### components/CensusChat.tsx
-- Chat UI with user/admin mode toggle
+- Chat UI with user/admin/fast-admin mode toggle
 - **User mode**: Searches stored stats, provides insights via `/api/insight`
 - **Admin mode**: Live Census API queries, adds new metrics via `/api/chat`
+- **Fast admin mode**: Direct Census variable lookup without LLM for quicker metric adds
 - Dispatches metrics to `MetricContext`
 
 ### components/MetricContext.tsx

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -78,6 +78,22 @@ export async function POST(req: NextRequest) {
 
   const { year = '2023', dataset = 'acs/acs5' } = config || {};
 
+  if (mode === 'fast-admin') {
+    const last = messages?.[messages.length - 1];
+    const query = last?.content || '';
+    const results = await searchCensus(query, year, dataset);
+    if (!results.length) {
+      return NextResponse.json({
+        message: { role: 'assistant', content: 'No matching variable found.' },
+      });
+    }
+    const top = results[0];
+    return NextResponse.json({
+      message: { role: 'assistant', content: `Added ${top.label}` },
+      toolInvocations: [{ name: 'add_metric', args: { id: top.id, label: top.label } }],
+    });
+  }
+
   const tools = [
     {
       type: 'function',

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -21,7 +21,7 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [mode, setMode] = useState<'user' | 'admin'>('user');
+  const [mode, setMode] = useState<'user' | 'admin' | 'fast-admin'>('user');
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
   const { metrics, clearMetrics } = useMetrics();
@@ -39,8 +39,8 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
       }
     }
     const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-    if (storedMode === 'user' || storedMode === 'admin') {
-      setMode(storedMode);
+    if (storedMode === 'user' || storedMode === 'admin' || storedMode === 'fast-admin') {
+      setMode(storedMode as 'user' | 'admin' | 'fast-admin');
     }
   }, []);
 
@@ -74,6 +74,28 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
           body: JSON.stringify({
             messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
             config,
+          }),
+        });
+        const data = await res.json();
+        setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
+        setLoading(false);
+
+        if (data.toolInvocations) {
+          for (const inv of data.toolInvocations) {
+            if (inv.name === 'add_metric') {
+              await onAddMetric(inv.args);
+            }
+          }
+        }
+      } else if (mode === 'fast-admin') {
+        setLoading(true);
+        const res = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            messages: [userMessage],
+            config,
+            mode: 'fast-admin',
           }),
         });
         const data = await res.json();
@@ -155,13 +177,14 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
           <select
             className="border border-gray-300 rounded p-1 text-sm"
             value={mode}
-            onChange={e => setMode(e.target.value as 'user' | 'admin')}
+            onChange={e => setMode(e.target.value as 'user' | 'admin' | 'fast-admin')}
           >
             <option value="user">User Mode</option>
             <option value="admin">Admin Mode</option>
+            <option value="fast-admin">Fast Admin Mode</option>
           </select>
         </div>
-        {mode === 'admin' && <ConfigControls />}
+        {mode !== 'user' && <ConfigControls />}
         <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
         {messages.map((m, idx) => (
           <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
@@ -180,7 +203,13 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
-            placeholder={mode === 'admin' ? 'Ask about US Census stats...' : 'Search stored stats...'}
+            placeholder={
+              mode === 'admin'
+                ? 'Ask about US Census stats...'
+                : mode === 'fast-admin'
+                ? 'Quickly add Census variables...'
+                : 'Search stored stats...'
+            }
           />
           <button
             className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"


### PR DESCRIPTION
## Summary
- add `fast-admin` mode to CensusChat for direct Census lookup without the LLM
- handle fast-admin requests in chat API using `searchCensus`
- document new chat mode in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a5342adfb4832d9ad28d85aed090a9