### PR TITLE
feat: add fast-admin chat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@
 - Populated from map click events
 
 ### components/CensusChat.tsx
-- Chat UI with user/admin mode toggle
+- Chat UI with user/admin/fast-admin mode toggle
 - **User mode**: Searches stored stats, provides insights via `/api/insight`
 - **Admin mode**: Live Census API queries, adds new metrics via `/api/chat`
+- **Fast Admin mode**: Uses a lightweight model with limited chat history for quicker Census variable search
 - Dispatches metrics to `MetricContext`
 
 ### components/MetricContext.tsx

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -75,7 +75,6 @@ export async function POST(req: NextRequest) {
       }
     }
   }
-
   const { year = '2023', dataset = 'acs/acs5' } = config || {};
 
   const tools = [
@@ -114,6 +113,52 @@ export async function POST(req: NextRequest) {
       },
     },
   ];
+
+  if (mode === 'fast-admin') {
+    const convo: Message[] = [...messages];
+    const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+    while (true) {
+      const response = await callOpenRouter({
+        model: 'openai/gpt-oss-120b:nitro',
+        messages: convo,
+        tools,
+        tool_choice: 'auto',
+        reasoning: { effort: 'low' },
+        text: { verbosity: 'low' },
+        max_output_tokens: 100,
+      });
+      const message = response.choices?.[0]?.message;
+      const toolCalls = message?.tool_calls ?? [];
+      convo.push(message as Message);
+      if (!toolCalls.length) {
+        if (message && 'reasoning' in (message as Record<string, unknown>)) {
+          delete (message as Record<string, unknown>).reasoning;
+        }
+        return NextResponse.json({ message, toolInvocations });
+      }
+      for (const call of toolCalls) {
+        const name = call.function.name;
+        const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
+        let result: unknown;
+        if (name === 'search_census') {
+          result = await searchCensus(args.query as string, year, dataset);
+        } else if (name === 'add_metric') {
+          const id = args.id as string;
+          if (await validateVariableId(id, year, dataset)) {
+            result = { ok: true };
+            toolInvocations.push({ name, args });
+          } else {
+            result = { ok: false, error: 'Unknown variable id' };
+          }
+        }
+        convo.push({
+          role: 'tool',
+          content: JSON.stringify(result),
+          tool_call_id: call.id,
+        });
+      }
+    }
+  }
 
   const convo: Message[] = [...messages];
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -17,11 +17,13 @@ interface CensusChatProps {
   onLoadStat: (stat: Stat) => void | Promise<void>;
 }
 
+type Mode = 'user' | 'admin' | 'fast-admin';
+
 export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [mode, setMode] = useState<'user' | 'admin'>('user');
+  const [mode, setMode] = useState<Mode>('user');
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
   const { metrics, clearMetrics } = useMetrics();
@@ -39,8 +41,8 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
       }
     }
     const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-    if (storedMode === 'user' || storedMode === 'admin') {
-      setMode(storedMode);
+    if (storedMode === 'user' || storedMode === 'admin' || storedMode === 'fast-admin') {
+      setMode(storedMode as Mode);
     }
   }, []);
 
@@ -65,15 +67,19 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
       setMessages(newMessages);
       setInput('');
 
-      if (mode === 'admin') {
+      if (mode === 'admin' || mode === 'fast-admin') {
         setLoading(true);
         const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
+        const history = mode === 'fast-admin'
+          ? [{ role: 'system', content: systemPrompt }, userMessage]
+          : [{ role: 'system', content: systemPrompt }, ...newMessages];
         const res = await fetch('/api/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
+            messages: history,
             config,
+            mode,
           }),
         });
         const data = await res.json();
@@ -155,13 +161,14 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
           <select
             className="border border-gray-300 rounded p-1 text-sm"
             value={mode}
-            onChange={e => setMode(e.target.value as 'user' | 'admin')}
+            onChange={e => setMode(e.target.value as Mode)}
           >
             <option value="user">User Mode</option>
             <option value="admin">Admin Mode</option>
+            <option value="fast-admin">Fast Admin Mode</option>
           </select>
         </div>
-        {mode === 'admin' && <ConfigControls />}
+        {(mode === 'admin' || mode === 'fast-admin') && <ConfigControls />}
         <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
         {messages.map((m, idx) => (
           <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
@@ -180,7 +187,7 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
-            placeholder={mode === 'admin' ? 'Ask about US Census stats...' : 'Search stored stats...'}
+            placeholder={mode === 'user' ? 'Search stored stats...' : 'Ask about US Census stats...'}
           />
           <button
             className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"


### PR DESCRIPTION
## Summary
- add `fast-admin` chat mode that uses a lightweight model with minimal context
- expose fast admin mode in CensusChat UI and document it

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5342adfb4832d9ad28d85aed090a9