### PR TITLE
Add map search with filter and highlighting

### DIFF
--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -13,6 +13,7 @@ interface OKCMapProps {
   organizations: Organization[];
   onOrganizationClick?: (org: Organization) => void;
   zctaFeatures?: ZctaFeature[];
+  highlightedOrgId?: string | null;
 }
 
 const OKC_CENTER = {
@@ -20,7 +21,7 @@ const OKC_CENTER = {
   latitude: 35.4676
 };
 
-export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures }: OKCMapProps) {
+export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures, highlightedOrgId }: OKCMapProps) {
   const [viewState, setViewState] = useState({
     longitude: OKC_CENTER.longitude,
     latitude: OKC_CENTER.latitude,
@@ -30,13 +31,13 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
   });
 
   const layers = useMemo(() => {
-    const layers: any[] = [createOrganizationLayer(organizations, onOrganizationClick)];
+    const layers: any[] = [createOrganizationLayer(organizations, onOrganizationClick, highlightedOrgId)];
     const zctaLayer = createZctaMetricLayer(zctaFeatures);
     if (zctaLayer) {
       layers.unshift(zctaLayer);
     }
     return layers;
-  }, [organizations, onOrganizationClick, zctaFeatures]);
+  }, [organizations, onOrganizationClick, zctaFeatures, highlightedOrgId]);
 
   return (
     <div className="w-full h-full relative">

--- a/components/OrganizationSearch.tsx
+++ b/components/OrganizationSearch.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import type { Organization } from '../types/organization';
+
+interface SearchBarProps {
+  query: string;
+  onQueryChange: (value: string) => void;
+  onSubmit: () => void;
+}
+
+export function SearchBar({ query, onQueryChange, onSubmit }: SearchBarProps) {
+  return (
+    <input
+      type="text"
+      value={query}
+      onChange={(e) => onQueryChange(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          onSubmit();
+        }
+      }}
+      placeholder="Search organizations..."
+      className="bg-white px-3 py-1 rounded shadow w-64 text-sm"
+    />
+  );
+}
+
+interface SearchResultsProps {
+  results: Organization[];
+  onSelect: (org: Organization) => void;
+  onHover: (orgId: string | null) => void;
+}
+
+export function SearchResults({ results, onSelect, onHover }: SearchResultsProps) {
+  return (
+    <div
+      className="w-96 bg-white shadow-lg overflow-y-auto"
+      onMouseLeave={() => onHover(null)}
+    >
+      <div className="p-4 space-y-2">
+        {results.length === 0 && (
+          <div className="text-sm text-gray-500">No organizations found.</div>
+        )}
+        {results.map((org) => (
+          <div
+            key={org.id}
+            className="p-2 border rounded cursor-pointer hover:bg-gray-50"
+            onClick={() => onSelect(org)}
+            onMouseEnter={() => onHover(org.id)}
+            onMouseLeave={() => onHover(null)}
+          >
+            <div className="font-semibold text-gray-900">{org.name}</div>
+            <div className="text-sm text-gray-600">{org.category}</div>
+            {org.locations[0] && (
+              <div className="text-xs text-gray-500">
+                {org.locations[0].address}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/lib/mapLayers.ts
+++ b/lib/mapLayers.ts
@@ -28,7 +28,8 @@ interface OrgPoint {
 
 export function createOrganizationLayer(
   organizations: Organization[],
-  onOrganizationClick?: (org: Organization) => void
+  onOrganizationClick?: (org: Organization) => void,
+  highlightedOrgId?: string | null,
 ) {
   const orgData: OrgPoint[] = organizations.flatMap((org) =>
     org.locations.map((location) => ({
@@ -42,10 +43,10 @@ export function createOrganizationLayer(
     id: 'organizations',
     data: orgData,
     getPosition: (d) => d.coordinates,
-    getRadius: 200,
+    getRadius: (d) => (d.organization.id === highlightedOrgId ? 300 : 200),
     getFillColor: (d) => d.color,
     getLineColor: [0, 0, 0, 100],
-    getLineWidth: 2,
+    getLineWidth: (d) => (d.organization.id === highlightedOrgId ? 4 : 2),
     radiusScale: 1,
     radiusMinPixels: 8,
     radiusMaxPixels: 20,


### PR DESCRIPTION
## Summary
- add floating search bar with searchable organization list
- filter map markers to match search results and keep bar over detail panel
- highlight organizations on map when hovering search results

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb7aa16c832db0d2f90d62d09a56