### PR TITLE
Add fast admin LLM mode with guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@
 - Side panel showing selected organization details
 - Populated from map click events
 
-### components/CensusChat.tsx
-- Chat UI with user/admin mode toggle
+-### components/CensusChat.tsx
+- Chat UI with user/admin/fast-admin mode toggle
 - **User mode**: Searches stored stats, provides insights via `/api/insight`
 - **Admin mode**: Live Census API queries, adds new metrics via `/api/chat`
+- **Fast Admin mode**: Uses a lightweight model with additional guardrails for quick Census searches and metric additions
 - Dispatches metrics to `MetricContext`
 
 ### components/MetricContext.tsx

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { searchCensus, validateVariableId } from '../../../lib/censusTools';
+import { searchCensus, validateVariableId, type CensusVariable } from '../../../lib/censusTools';
 import { callOpenRouter } from '../../../lib/openRouter';
 
 interface Message {
@@ -66,6 +66,100 @@ export async function POST(req: NextRequest) {
           toolInvocations.push({ name: 'select_stat', args: { code } });
         } else {
           result = { ok: false, error: 'Unknown code' };
+        }
+        convo.push({
+          role: 'tool',
+          content: JSON.stringify(result),
+          tool_call_id: call.id,
+        });
+      }
+    }
+  }
+
+  if (mode === 'fast-admin') {
+    const { year = '2023', dataset = 'acs/acs5' } = config || {};
+
+    const tools = [
+      {
+        type: 'function',
+        function: {
+          name: 'search_census',
+          description:
+            `Search the US Census ${year} ${dataset} dataset for variables matching a query. Returns a list of matching variable ids and descriptions.`,
+          parameters: {
+            type: 'object',
+            properties: {
+              query: {
+                type: 'string',
+                description: 'Search term for the desired statistic',
+              },
+            },
+            required: ['query'],
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'add_metric',
+          description:
+            "Add a Census variable to the user's metric selection dropdown. Provide the variable id and a human readable label.",
+          parameters: {
+            type: 'object',
+            properties: {
+              id: { type: 'string', description: 'Variable identifier' },
+              label: { type: 'string', description: 'Human readable label' },
+            },
+            required: ['id', 'label'],
+          },
+        },
+      },
+    ];
+
+    const convo: Message[] = [...messages];
+    const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+    let lastResults: CensusVariable[] = [];
+
+    while (true) {
+      const response = await callOpenRouter({
+        model: 'openai/gpt-oss-120b:nitro',
+        messages: convo,
+        tools,
+        tool_choice: 'auto',
+        reasoning: { effort: 'low' },
+        text: { verbosity: 'low' },
+      });
+
+      const message = response.choices?.[0]?.message;
+      const toolCalls = message?.tool_calls ?? [];
+      convo.push(message as Message);
+
+      if (!toolCalls.length) {
+        if (message && 'reasoning' in (message as Record<string, unknown>)) {
+          delete (message as Record<string, unknown>).reasoning;
+        }
+        return NextResponse.json({
+          message,
+          toolInvocations,
+        });
+      }
+
+      for (const call of toolCalls) {
+        const name = call.function.name;
+        const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
+        let result: unknown;
+        if (name === 'search_census') {
+          lastResults = await searchCensus(args.query as string, year, dataset);
+          result = lastResults;
+        } else if (name === 'add_metric') {
+          const id = args.id as string;
+          const valid = lastResults.some((r) => r.id === id);
+          if (valid && (await validateVariableId(id, year, dataset))) {
+            result = { ok: true };
+            toolInvocations.push({ name, args });
+          } else {
+            result = { ok: false, error: 'Unknown variable id' };
+          }
         }
         convo.push({
           role: 'tool',

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -21,7 +21,7 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [mode, setMode] = useState<'user' | 'admin'>('user');
+  const [mode, setMode] = useState<'user' | 'admin' | 'fast-admin'>('user');
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
   const { metrics, clearMetrics } = useMetrics();
@@ -39,7 +39,7 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
       }
     }
     const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-    if (storedMode === 'user' || storedMode === 'admin') {
+    if (storedMode === 'user' || storedMode === 'admin' || storedMode === 'fast-admin') {
       setMode(storedMode);
     }
   }, []);
@@ -65,7 +65,7 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
       setMessages(newMessages);
       setInput('');
 
-      if (mode === 'admin') {
+      if (mode === 'admin' || mode === 'fast-admin') {
         setLoading(true);
         const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
         const res = await fetch('/api/chat', {
@@ -74,6 +74,7 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
           body: JSON.stringify({
             messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
             config,
+            ...(mode === 'fast-admin' ? { mode: 'fast-admin' } : {}),
           }),
         });
         const data = await res.json();
@@ -155,13 +156,14 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
           <select
             className="border border-gray-300 rounded p-1 text-sm"
             value={mode}
-            onChange={e => setMode(e.target.value as 'user' | 'admin')}
+            onChange={e => setMode(e.target.value as 'user' | 'admin' | 'fast-admin')}
           >
             <option value="user">User Mode</option>
             <option value="admin">Admin Mode</option>
+            <option value="fast-admin">Fast Admin Mode</option>
           </select>
         </div>
-        {mode === 'admin' && <ConfigControls />}
+        {(mode === 'admin' || mode === 'fast-admin') && <ConfigControls />}
         <div className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100">
         {messages.map((m, idx) => (
           <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
@@ -180,7 +182,7 @@ export default function CensusChat({ onAddMetric, onLoadStat }: CensusChatProps)
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
-            placeholder={mode === 'admin' ? 'Ask about US Census stats...' : 'Search stored stats...'}
+            placeholder={mode === 'admin' || mode === 'fast-admin' ? 'Ask about US Census stats...' : 'Search stored stats...'}
           />
           <button
             className="px-4 py-2 bg-blue-600 text-white rounded-r disabled:opacity-50"


### PR DESCRIPTION
## Summary
- add `fast-admin` chat mode using OpenRouter `openai/gpt-oss-120b:nitro`
- enforce search-before-add guardrails in chat API
- expose mode option in CensusChat UI and docs

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cdb1b100832db75b9dfa29e22ccc