### PR TITLE
feat: add map search with results sidebar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,8 @@ import CensusChat from '../components/CensusChat';
 import TopNav from '../components/TopNav';
 import { useMetrics } from '../components/MetricContext';
 import OrganizationDetails from '../components/OrganizationDetails';
+import SearchBar from '../components/SearchBar';
+import SearchResults from '../components/SearchResults';
 import type { Organization } from '../types/organization';
 
 const OKCMap = dynamic(() => import('../components/OKCMap'), {
@@ -18,6 +20,9 @@ const OKCMap = dynamic(() => import('../components/OKCMap'), {
 export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Organization[] | null>(null);
+  const [hoveredOrgId, setHoveredOrgId] = useState<string | null>(null);
   const { zctaFeatures, addMetric, loadStatMetric } = useMetrics();
 
   const { data, isLoading, error } = db.useQuery({
@@ -45,6 +50,23 @@ export default function Home() {
   }
 
   const organizations = data?.organizations || [];
+  const displayedOrganizations = searchResults ?? organizations;
+
+  const handleSearch = () => {
+    const term = searchQuery.trim().toLowerCase();
+    if (!term) {
+      setSearchResults(null);
+      setSelectedOrg(null);
+      return;
+    }
+    const results = organizations.filter((org) =>
+      org.name.toLowerCase().includes(term) ||
+      org.description.toLowerCase().includes(term) ||
+      org.category.toLowerCase().includes(term)
+    );
+    setSearchResults(results);
+    setSelectedOrg(null);
+  };
 
   return (
     <div className="h-screen bg-gray-100 flex flex-col overflow-hidden">
@@ -54,19 +76,60 @@ export default function Home() {
         onAddOrganization={() => setShowAddForm(true)}
       />
 
-      <div className="flex flex-1 overflow-hidden">
-        {selectedOrg && (
-          <OrganizationDetails
-            organization={selectedOrg}
-            onClose={() => setSelectedOrg(null)}
-          />
+      <div className="flex flex-1 overflow-hidden relative">
+        {(selectedOrg || searchResults) && (
+          <div className="w-96 ml-4 mt-16">
+            {selectedOrg ? (
+              <OrganizationDetails
+                organization={selectedOrg}
+                onClose={() => {
+                  setSelectedOrg(null);
+                  setHoveredOrgId(null);
+                }}
+              />
+            ) : (
+              searchResults && (
+                <SearchResults
+                  results={searchResults}
+                  onSelect={(org) => {
+                    setSelectedOrg(org);
+                    setHoveredOrgId(null);
+                  }}
+                  onHover={(org) => setHoveredOrgId(org ? org.id : null)}
+                />
+              )
+            )}
+          </div>
         )}
 
         <div className="flex-1 relative">
           <OKCMap
-            organizations={organizations}
+            organizations={displayedOrganizations}
             onOrganizationClick={setSelectedOrg}
             zctaFeatures={zctaFeatures}
+            highlightedOrgId={hoveredOrgId ?? undefined}
+          />
+        </div>
+
+        <div className="absolute top-4 left-4 z-10 w-96">
+          <SearchBar
+            value={searchQuery}
+            onChange={(val) => {
+              setSearchQuery(val);
+              if (val.trim() === '') {
+                setSearchResults(null);
+                setSelectedOrg(null);
+                setHoveredOrgId(null);
+              }
+            }}
+            onSubmit={handleSearch}
+            onClear={() => {
+              setSearchQuery('');
+              setSearchResults(null);
+              setSelectedOrg(null);
+              setHoveredOrgId(null);
+            }}
+            showClear={searchResults !== null}
           />
         </div>
       </div>

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -13,6 +13,7 @@ interface OKCMapProps {
   organizations: Organization[];
   onOrganizationClick?: (org: Organization) => void;
   zctaFeatures?: ZctaFeature[];
+  highlightedOrgId?: string;
 }
 
 const OKC_CENTER = {
@@ -20,7 +21,7 @@ const OKC_CENTER = {
   latitude: 35.4676
 };
 
-export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures }: OKCMapProps) {
+export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures, highlightedOrgId }: OKCMapProps) {
   const [viewState, setViewState] = useState({
     longitude: OKC_CENTER.longitude,
     latitude: OKC_CENTER.latitude,
@@ -30,13 +31,15 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
   });
 
   const layers = useMemo(() => {
-    const layers: any[] = [createOrganizationLayer(organizations, onOrganizationClick)];
+    const layers: any[] = [
+      createOrganizationLayer(organizations, onOrganizationClick, highlightedOrgId)
+    ];
     const zctaLayer = createZctaMetricLayer(zctaFeatures);
     if (zctaLayer) {
       layers.unshift(zctaLayer);
     }
     return layers;
-  }, [organizations, onOrganizationClick, zctaFeatures]);
+  }, [organizations, onOrganizationClick, zctaFeatures, highlightedOrgId]);
 
   return (
     <div className="w-full h-full relative">

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React, { KeyboardEvent } from 'react';
+
+interface SearchBarProps {
+  value: string;
+  onChange: (val: string) => void;
+  onSubmit: () => void;
+  onClear: () => void;
+  showClear: boolean;
+}
+
+export default function SearchBar({ value, onChange, onSubmit, onClear, showClear }: SearchBarProps) {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onSubmit();
+    }
+  };
+
+  return (
+    <div className="relative w-full">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Search organizations..."
+        className="px-3 py-2 border rounded shadow bg-white text-sm w-full focus:outline-none focus:ring"
+      />
+      {showClear && (
+        <button
+          onClick={onClear}
+          aria-label="Clear search"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from 'react';
+import type { Organization } from '../types/organization';
+
+interface SearchResultsProps {
+  results: Organization[];
+  onSelect: (org: Organization) => void;
+  onHover: (org: Organization | null) => void;
+}
+
+export default function SearchResults({ results, onSelect, onHover }: SearchResultsProps) {
+  return (
+    <div className="w-full overflow-y-auto p-4 space-y-3">
+      {results.length === 0 && (
+        <div className="text-sm text-gray-500">No results found</div>
+      )}
+      {results.map((org) => (
+        <div
+          key={org.id}
+          className="p-3 bg-white border rounded cursor-pointer hover:bg-gray-50"
+          onClick={() => onSelect(org)}
+          onMouseEnter={() => onHover(org)}
+          onMouseLeave={() => onHover(null)}
+        >
+          <h3 className="font-semibold text-gray-900">{org.name}</h3>
+          <p className="text-xs text-gray-600 line-clamp-2">{org.description}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/mapLayers.ts
+++ b/lib/mapLayers.ts
@@ -28,7 +28,8 @@ interface OrgPoint {
 
 export function createOrganizationLayer(
   organizations: Organization[],
-  onOrganizationClick?: (org: Organization) => void
+  onOrganizationClick?: (org: Organization) => void,
+  highlightedOrgId?: string
 ) {
   const orgData: OrgPoint[] = organizations.flatMap((org) =>
     org.locations.map((location) => ({
@@ -42,10 +43,11 @@ export function createOrganizationLayer(
     id: 'organizations',
     data: orgData,
     getPosition: (d) => d.coordinates,
-    getRadius: 200,
+    getRadius: (d) => (d.organization.id === highlightedOrgId ? 300 : 200),
     getFillColor: (d) => d.color,
-    getLineColor: [0, 0, 0, 100],
-    getLineWidth: 2,
+    getLineColor: (d) =>
+      d.organization.id === highlightedOrgId ? [0, 0, 0, 255] : [0, 0, 0, 100],
+    getLineWidth: (d) => (d.organization.id === highlightedOrgId ? 4 : 2),
     radiusScale: 1,
     radiusMinPixels: 8,
     radiusMaxPixels: 20,


### PR DESCRIPTION
## Summary
- add floating search bar with enter-to-search behavior
- render matching organizations in a left sidebar and filter map markers
- highlight organizations on map when hovering search results
- allow clearing searches via an "x" and hide sidebar when query is empty
- show search results cards directly on the grey sidebar background

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5cb7aa16c832db0d2f90d62d09a56