### PR TITLE
feat: streamline census chat with smart routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
 - Collapsible `CensusChat` container anchored bottom-right
 
 ### app/api/chat/route.ts
-- POST handler forwarding prompts to OpenRouter
+- Smart chat handler that detects simple add commands and variable ids
+- Falls back to OpenRouter with tool calls for deeper questions
 - Uses `censusTools` helpers for variable search/validation
 - Called by `CensusChat`
 
@@ -73,11 +74,11 @@
 - Populated from map click events
 
 ### components/CensusChat.tsx
-- Chat UI with user/admin mode toggle
-- **User mode**: Searches stored stats, provides insights via `/api/insight`
-- **Admin mode**: Live Census API queries, adds new metrics via `/api/chat`
+- Chat UI that automatically routes requests via `/api/chat`
+- Detects direct variable ids and short add commands for instant metric loading
+- Falls back to OpenRouter for answering questions and fetching new stats
 - Dispatches metrics to `MetricContext`
-- Persists chat messages and mode selection to localStorage
+- Persists chat messages to localStorage
 - Collapsible container with reopen button; clear controls for chat and active metrics
 
 ### components/MetricContext.tsx
@@ -117,7 +118,7 @@
 
 ### lib/censusTools.ts
 - Loads Census variable metadata and caches results
-- `searchCensus` and `validateVariableId` helpers
+- `searchCensus` and `validateVariableId` helpers with tokenized search for loose queries
 
 ### lib/mapLayers.ts
 - `createOrganizationLayer` for point markers

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,90 +8,80 @@ interface Message {
   tool_call_id?: string;
 }
 
+const VAR_ID = /[A-Z][0-9]{5}_[0-9]{3}[A-Z]?E/;
+const ID_LIST = new RegExp(`^${VAR_ID.source}(\s*,\s*${VAR_ID.source})*$`);
+const ACTION = /^(add|map|show|plot|display|load)\s+([a-z0-9\s]{1,50})$/i;
 
 export async function POST(req: NextRequest) {
-  const { messages, config, mode, stats } = await req.json();
+  const { messages, config, stats, activeStats, metrics } = await req.json();
+  const last = messages[messages.length - 1];
+  const text = (last?.content || '').trim();
+  const { year = '2023', dataset = 'acs/acs5' } = config || {};
 
-  if (mode === 'user') {
-    const tools = [
-      {
-        type: 'function',
-        function: {
-          name: 'select_stat',
-          description: 'Select the best matching statistic code from the provided list.',
-          parameters: {
-            type: 'object',
-            properties: {
-              code: { type: 'string', description: 'Statistic code' },
-            },
-            required: ['code'],
-          },
-        },
-      },
-    ];
-    const list = (stats || [])
-      .map((s: { code: string; description: string }) => `${s.code}: ${s.description}`)
-      .join('\n');
-    const convo: Message[] = [
-      { role: 'system', content: `You know about these stats:\n${list}` },
-      ...(messages ? messages.slice(-1) : []),
-    ];
+  if (ID_LIST.test(text)) {
+    const ids = text.split(/\s*,\s*/);
     const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
-    while (true) {
-      const response = await callOpenRouter({
-        model: 'openai/gpt-oss-120b:nitro',
-        messages: convo,
-        tools,
-        tool_choice: 'auto',
-        reasoning: { effort: 'low' },
-        text: { verbosity: 'low' },
-        max_output_tokens: 100,
-      });
-      const message = response.choices?.[0]?.message;
-      const toolCalls = message?.tool_calls ?? [];
-      convo.push(message as Message);
-      if (!toolCalls.length) {
-        if (message && 'reasoning' in (message as Record<string, unknown>)) {
-          delete (message as Record<string, unknown>).reasoning;
-        }
-        return NextResponse.json({ message, toolInvocations });
+    const labels: string[] = [];
+    for (const id of ids) {
+      if (await validateVariableId(id, year, dataset)) {
+        const match = (await searchCensus(id, year, dataset)).find(v => v.id === id);
+        const label = match?.label || id;
+        toolInvocations.push({ name: 'add_metric', args: { id, label } });
+        labels.push(`"${label}"`);
       }
-      for (const call of toolCalls) {
-        const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
-        const code = args.code as string;
-        const exists = (stats || []).some((s: { code: string }) => s.code === code);
-        let result: unknown;
-        if (exists) {
-          result = { ok: true };
-          toolInvocations.push({ name: 'select_stat', args: { code } });
-        } else {
-          result = { ok: false, error: 'Unknown code' };
-        }
-        convo.push({
-          role: 'tool',
-          content: JSON.stringify(result),
-          tool_call_id: call.id,
+    }
+    const content = labels.length
+      ? `Added ${labels.join(', ')} to your metrics list.`
+      : 'No valid Census variable ids provided.';
+    return NextResponse.json({
+      message: { role: 'assistant', content },
+      toolInvocations,
+    });
+  }
+
+  const action = text.match(ACTION);
+  if (action) {
+    const query = action[2].trim();
+    const wordCount = query.split(/\s+/).length;
+    if (wordCount >= 1 && wordCount <= 7 && !/[.?]/.test(query)) {
+      const results = await searchCensus(query, year, dataset);
+      if (results.length) {
+        const best = results[0];
+        const toolInvocations = [
+          { name: 'add_metric', args: { id: best.id, label: best.label } },
+        ];
+        return NextResponse.json({
+          message: { role: 'assistant', content: `Added "${best.label}" to your metrics list.` },
+          toolInvocations,
         });
       }
+      return handleConversational(messages, config, stats, activeStats, metrics, true, query);
     }
   }
 
-  const { year = '2023', dataset = 'acs/acs5' } = config || {};
+  return handleConversational(messages, config, stats, activeStats, metrics);
+}
 
+async function handleConversational(
+  messages: Message[],
+  config: Record<string, unknown>,
+  stats: Array<{ code: string; description: string }> = [],
+  activeStats: Array<{ code: string; description: string; data: unknown }> = [],
+  metrics: Array<{ id: string; label: string }> = [],
+  startDeep = false,
+  failedQuery = ''
+) {
+  const { year = '2023', dataset = 'acs/acs5' } = config || {};
   const tools = [
     {
       type: 'function',
       function: {
         name: 'search_census',
-        description:
-          `Search the US Census ${year} ${dataset} dataset for variables matching a query. Returns a list of matching variable ids and descriptions.`,
+        description: `Search the US Census ${year} ${dataset} dataset for variables matching a query. Returns a list of matching variable ids and descriptions.`,
         parameters: {
           type: 'object',
           properties: {
-            query: {
-              type: 'string',
-              description: 'Search term for the desired statistic',
-            },
+            query: { type: 'string', description: 'Search term for the desired statistic' },
           },
           required: ['query'],
         },
@@ -113,33 +103,74 @@ export async function POST(req: NextRequest) {
         },
       },
     },
+    {
+      type: 'function',
+      function: {
+        name: 'select_stat',
+        description: 'Select the best matching statistic code from the provided list.',
+        parameters: {
+          type: 'object',
+          properties: { code: { type: 'string', description: 'Statistic code' } },
+          required: ['code'],
+        },
+      },
+    },
   ];
 
   const convo: Message[] = [...messages];
+  if (stats.length) {
+    const list = stats.map(s => `${s.code}: ${s.description}`).join('\n');
+    convo.splice(1, 0, { role: 'system', content: `Available stats:\n${list}` });
+  }
+  if (activeStats.length) {
+    convo.splice(1, 0, {
+      role: 'system',
+      content: `Active stats data: ${JSON.stringify(activeStats)}`,
+    });
+  }
+  if (metrics.length) {
+    const names = metrics.map(m => m.label).join(', ');
+    convo.splice(1, 0, { role: 'system', content: `Loaded metrics: ${names}` });
+  }
+  if (startDeep && failedQuery) {
+    convo.push({
+      role: 'system',
+      content: `Initial search for "${failedQuery}" returned no results. Try a different approach.`,
+    });
+  }
+
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+  let model = startDeep ? 'openai/gpt-5-mini' : 'openai/gpt-oss-120b:nitro';
+  let lastSearchEmpty = false;
 
   while (true) {
     const response = await callOpenRouter({
-      model: 'openai/gpt-5-mini',
+      model,
       messages: convo,
       tools,
       tool_choice: 'auto',
-      reasoning: { effort: "low" },
-      text: { verbosity: "low" },
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+      max_output_tokens: 200,
     });
-
     const message = response.choices?.[0]?.message;
     const toolCalls = message?.tool_calls ?? [];
     convo.push(message as Message);
 
     if (!toolCalls.length) {
+      if (lastSearchEmpty && model === 'openai/gpt-oss-120b:nitro') {
+        model = 'openai/gpt-5-mini';
+        convo.push({
+          role: 'system',
+          content: 'Previous Census search returned no results. Search deeper or explain.',
+        });
+        lastSearchEmpty = false;
+        continue;
+      }
       if (message && 'reasoning' in (message as Record<string, unknown>)) {
         delete (message as Record<string, unknown>).reasoning;
       }
-      return NextResponse.json({
-        message,
-        toolInvocations,
-      });
+      return NextResponse.json({ message, toolInvocations });
     }
 
     for (const call of toolCalls) {
@@ -147,14 +178,26 @@ export async function POST(req: NextRequest) {
       const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
       let result: unknown;
       if (name === 'search_census') {
-        result = await searchCensus(args.query as string, year, dataset);
+        const searchResults = await searchCensus(args.query as string, year, dataset);
+        lastSearchEmpty = searchResults.length === 0;
+        result = searchResults;
       } else if (name === 'add_metric') {
         const id = args.id as string;
+        const label = args.label as string;
         if (await validateVariableId(id, year, dataset)) {
           result = { ok: true };
-          toolInvocations.push({ name, args });
+          toolInvocations.push({ name, args: { id, label } });
         } else {
           result = { ok: false, error: 'Unknown variable id' };
+        }
+      } else if (name === 'select_stat') {
+        const code = args.code as string;
+        const exists = stats.some(s => s.code === code);
+        if (exists) {
+          result = { ok: true };
+          toolInvocations.push({ name, args: { code } });
+        } else {
+          result = { ok: false, error: 'Unknown code' };
         }
       }
       convo.push({

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -22,7 +22,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [mode, setMode] = useState<'user' | 'admin'>('user');
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
   const { metrics, clearMetrics } = useMetrics();
@@ -30,8 +29,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const CHAT_STORAGE_KEY = 'censusChatMessages';
-  const MODE_STORAGE_KEY = 'censusChatMode';
-
   useEffect(() => {
     const stored = localStorage.getItem(CHAT_STORAGE_KEY);
     if (stored) {
@@ -40,10 +37,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
       } catch {
         /* ignore */
       }
-    }
-    const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-    if (storedMode === 'user' || storedMode === 'admin') {
-      setMode(storedMode);
     }
   }, []);
 
@@ -61,10 +54,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
     });
   }, [messages, loading]);
 
-  useEffect(() => {
-    localStorage.setItem(MODE_STORAGE_KEY, mode);
-  }, [mode]);
-
   // Auto-resize input area based on content
   useEffect(() => {
     const el = inputRef.current;
@@ -79,89 +68,50 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
     clearMetrics();
   };
 
-    const sendMessage = async () => {
-      if (!input.trim()) return;
-      const userMessage = { role: 'user' as const, content: input };
-      const newMessages = [...messages, userMessage];
-      setMessages(newMessages);
-      setInput('');
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMessage = { role: 'user' as const, content: input };
+    const newMessages = [...messages, userMessage];
+    setMessages(newMessages);
+    setInput('');
 
-      if (mode === 'admin') {
-        setLoading(true);
-        const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
-        const res = await fetch('/api/chat', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
-            config,
-          }),
-        });
-        const data = await res.json();
-        setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
-        setLoading(false);
+    setLoading(true);
+    const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
+    const stats = (statData?.stats || []) as Stat[];
+    const activeStats = stats.filter(s => metrics.some(m => m.id === s.code));
+    const body: Record<string, unknown> = {
+      messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
+      config,
+      stats: stats.map(s => ({ code: s.code, description: s.description })),
+      activeStats: activeStats.map(s => ({
+        code: s.code,
+        description: s.description,
+        data: JSON.parse(s.data),
+      })),
+      metrics: metrics.map(m => ({ id: m.id, label: m.label })),
+    };
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    setLoading(false);
+    setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
 
-        if (data.toolInvocations) {
-          for (const inv of data.toolInvocations) {
-            if (inv.name === 'add_metric') {
-              await onAddMetric(inv.args);
-            }
-          }
+    if (data.toolInvocations) {
+      for (const inv of data.toolInvocations) {
+        if (inv.name === 'add_metric') {
+          await onAddMetric(inv.args);
         }
-      } else {
-        setLoading(true);
-        const stats = (statData?.stats || []) as Stat[];
-        const isAction = /\b(add|show|map)\b/i.test(userMessage.content);
-        if (isAction) {
-          const res = await fetch('/api/chat', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              messages: [userMessage],
-              mode: 'user',
-              stats: stats.map(s => ({ code: s.code, description: s.description })),
-            }),
-          });
-          const data = await res.json();
-          setLoading(false);
-          type ToolInvocation = { name: string; args: Record<string, unknown> };
-          const inv = (data.toolInvocations as ToolInvocation[] | undefined)?.find(
-            (i) => i.name === 'select_stat'
-          );
-          if (inv && typeof inv.args.code === 'string') {
-            const code = inv.args.code as string;
-            const stat = stats.find(s => s.code === code);
-            if (stat) {
-              await onLoadStat(stat);
-              setMessages([...newMessages, { role: 'assistant', content: 'Added to map!' }]);
-            } else {
-              setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
-            }
-          } else {
-            setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
-          }
-        } else {
-          const activeStats = stats.filter(s =>
-            metrics.some(m => m.id === s.code)
-          );
-          const res = await fetch('/api/insight', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              messages: newMessages,
-              stats: activeStats.map(s => ({
-                code: s.code,
-                description: s.description,
-                data: JSON.parse(s.data),
-              })),
-            }),
-          });
-          const data = await res.json();
-          setLoading(false);
-          setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
+        if (inv.name === 'select_stat') {
+          const code = inv.args.code as string;
+          const stat = stats.find(s => s.code === code);
+          if (stat) await onLoadStat(stat);
         }
       }
-    };
+    }
+  };
 
     return (
       <div className="flex flex-col h-full bg-white text-gray-900">
@@ -176,48 +126,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
                 add map data &amp; chat
               </div>
             </span>
-            <div
-              className="relative"
-              style={{ display: 'inline-block' }}
-            >
-              <select
-                className="border transition-colors pr-8"
-                style={{
-                  paddingTop: 'var(--spacing-2)',
-                  paddingBottom: 'var(--spacing-2)',
-                  paddingLeft: 'var(--spacing-4)',
-                  paddingRight: 'var(--spacing-10)', // extra right padding for chevron
-                  borderRadius: 'var(--radius-field)', // 8px
-                  backgroundColor: 'var(--color-base-100)',
-                  color: 'var(--color-base-content)',
-                  borderColor: 'var(--color-base-300)',
-                  fontSize: 'var(--font-size-sm)', // 14px
-                  appearance: 'none',
-                  WebkitAppearance: 'none',
-                  MozAppearance: 'none',
-                }}
-                value={mode}
-                onChange={e => setMode(e.target.value as 'user' | 'admin')}
-              >
-                <option value="user">User Mode</option>
-                <option value="admin">Admin Mode</option>
-              </select>
-              {/* Down chevron icon, with right padding */}
-              <span
-                className="pointer-events-none absolute inset-y-0 right-0 flex items-center"
-                style={{ paddingRight: 'var(--spacing-3)' }}
-              >
-                <svg
-                  className="w-2 h-2 text-gray-400"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                </svg>
-              </span>
-            </div>
             <button
               onClick={clearChat}
               className="px-2 py-1 border rounded text-xs text-gray-600"
@@ -238,7 +146,7 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
             </button>
           )}
         </div>
-        {mode === 'admin' && <ConfigControls />}
+        <ConfigControls />
         <div
           ref={scrollContainerRef}
           className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100"
@@ -275,7 +183,7 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
                 sendMessage();
               }
             }}
-            placeholder={mode === 'admin' ? 'Ask about US Census stats... (Shift+Enter for newline)' : 'Search stored stats...'}
+            placeholder="Ask about US Census stats... (Shift+Enter for newline)"
           />
           {/* Hide scrollbar for Webkit browsers */}
           <style jsx>{`

--- a/lib/censusQueryMap.ts
+++ b/lib/censusQueryMap.ts
@@ -15,4 +15,7 @@ export const COMMON_QUERY_MAP: Record<string, CensusVariableInfo> = {
   'total population': find('B01003_001E'),
   population: find('B01003_001E'),
   'per capita income': find('B19301_001E'),
+  'latino population': find('B03003_003E'),
+  'hispanic population': find('B03003_003E'),
+  'hispanic or latino population': find('B03003_003E'),
 };

--- a/lib/censusTools.ts
+++ b/lib/censusTools.ts
@@ -2,6 +2,8 @@ import { addLog } from './logStore';
 import { CURATED_VARIABLES } from './censusVariables';
 import { COMMON_QUERY_MAP } from './censusQueryMap';
 
+const STOP_WORDS = new Set(['and', 'or', 'of', 'the', 'in', 'for', 'population']);
+
 export interface CensusVariable {
   id: string;
   label: string;
@@ -56,7 +58,9 @@ export async function searchCensus(
     return result;
   }
 
-  const tokens = q.split(/\s+/);
+  const tokens = q
+    .split(/\s+/)
+    .filter((t) => t && !STOP_WORDS.has(t));
   const curated = CURATED_VARIABLES.filter((v) =>
     tokens.every(
       (t) =>
@@ -77,7 +81,9 @@ export async function searchCensus(
     message: { type: 'search', query, year, dataset },
   });
   const results = vars
-    .filter(([, info]) => info.label.toLowerCase().includes(q))
+    .filter(([, info]) =>
+      tokens.every((t) => info.label.toLowerCase().includes(t))
+    )
     .slice(0, 5)
     .map(([id, info]) => ({ id, label: info.label, concept: info.concept }));
   searchCache.set(cacheKey, results);

--- a/lib/censusVariables.ts
+++ b/lib/censusVariables.ts
@@ -24,4 +24,10 @@ export const CURATED_VARIABLES: CensusVariableInfo[] = [
     concept: 'INCOME IN THE PAST 12 MONTHS (IN 2023 INFLATION-ADJUSTED DOLLARS)',
     keywords: ['per', 'capita', 'income'],
   },
+  {
+    id: 'B03003_003E',
+    label: 'Hispanic or Latino population',
+    concept: 'Hispanic or Latino Origin',
+    keywords: ['hispanic', 'latino'],
+  },
 ];


### PR DESCRIPTION
## Summary
- auto-detect metric ids or short add commands for instant Census lookups
- fall back to LLM-driven flow with deeper search when needed
- remove manual chat modes and streamline UI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a88dd3df64832db39b0a0ff4febc0f