### PR TITLE
feat: streamline census chat heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,13 @@
 - Collapsible `CensusChat` container anchored bottom-right
 
 ### app/api/chat/route.ts
-- POST handler forwarding prompts to OpenRouter
-- Uses `censusTools` helpers for variable search/validation
-- Called by `CensusChat`
+- POST handler orchestrating chat responses and Census lookups
+- Heuristically adds metrics for plain ID lists or short action commands
+- Falls back to OpenRouter models for reasoning and deeper searches
 
 ### app/api/insight/route.ts
 - POST handler for free-form statistical analysis
 - Processes stat data through OpenRouter for insights
-- Called by `CensusChat` in insight mode
 
 ### app/api/logs/route.ts
 - In-memory log store for external request debugging
@@ -73,11 +72,10 @@
 - Populated from map click events
 
 ### components/CensusChat.tsx
-- Chat UI with user/admin mode toggle
-- **User mode**: Searches stored stats, provides insights via `/api/insight`
-- **Admin mode**: Live Census API queries, adds new metrics via `/api/chat`
-- Dispatches metrics to `MetricContext`
-- Persists chat messages and mode selection to localStorage
+- Single chat interface for questions and metric requests
+- Detects simple commands locally and loads stats automatically
+- Sends conversation and stats context to `/api/chat`
+- Persists chat messages to localStorage
 - Collapsible container with reopen button; clear controls for chat and active metrics
 
 ### components/MetricContext.tsx
@@ -117,7 +115,7 @@
 
 ### lib/censusTools.ts
 - Loads Census variable metadata and caches results
-- `searchCensus` and `validateVariableId` helpers
+- `searchCensus` and `validateVariableId` helpers with tokenized search for loose queries
 
 ### lib/mapLayers.ts
 - `createOrganizationLayer` for point markers

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { searchCensus, validateVariableId } from '../../../lib/censusTools';
+import {
+  searchCensus,
+  validateVariableId,
+  getVariableById,
+  type CensusVariable,
+} from '../../../lib/censusTools';
 import { callOpenRouter } from '../../../lib/openRouter';
 
 interface Message {
@@ -8,76 +13,32 @@ interface Message {
   tool_call_id?: string;
 }
 
+function parseMetricIds(input: string): string[] {
+  const trimmed = input.trim();
+  if (!trimmed) return [];
+  const idList = trimmed.match(
+    /^([A-Z]\d{5}_\d{3}E)(\s*,\s*[A-Z]\d{5}_\d{3}E)*$/i
+  );
+  if (!idList) return [];
+  return trimmed.split(/\s*,\s*/);
+}
 
-export async function POST(req: NextRequest) {
-  const { messages, config, mode, stats } = await req.json();
+function parseActionQuery(input: string): string | null {
+  const match = input.trim().match(/^(add|map|show)\s+([^?!.]+)$/i);
+  if (!match) return null;
+  const rest = match[2].trim();
+  const words = rest.split(/\s+/);
+  if (words.length < 1 || words.length > 7) return null;
+  return rest;
+}
 
-  if (mode === 'user') {
-    const tools = [
-      {
-        type: 'function',
-        function: {
-          name: 'select_stat',
-          description: 'Select the best matching statistic code from the provided list.',
-          parameters: {
-            type: 'object',
-            properties: {
-              code: { type: 'string', description: 'Statistic code' },
-            },
-            required: ['code'],
-          },
-        },
-      },
-    ];
-    const list = (stats || [])
-      .map((s: { code: string; description: string }) => `${s.code}: ${s.description}`)
-      .join('\n');
-    const convo: Message[] = [
-      { role: 'system', content: `You know about these stats:\n${list}` },
-      ...(messages ? messages.slice(-1) : []),
-    ];
-    const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
-    while (true) {
-      const response = await callOpenRouter({
-        model: 'openai/gpt-oss-120b:nitro',
-        messages: convo,
-        tools,
-        tool_choice: 'auto',
-        reasoning: { effort: 'low' },
-        text: { verbosity: 'low' },
-        max_output_tokens: 100,
-      });
-      const message = response.choices?.[0]?.message;
-      const toolCalls = message?.tool_calls ?? [];
-      convo.push(message as Message);
-      if (!toolCalls.length) {
-        if (message && 'reasoning' in (message as Record<string, unknown>)) {
-          delete (message as Record<string, unknown>).reasoning;
-        }
-        return NextResponse.json({ message, toolInvocations });
-      }
-      for (const call of toolCalls) {
-        const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
-        const code = args.code as string;
-        const exists = (stats || []).some((s: { code: string }) => s.code === code);
-        let result: unknown;
-        if (exists) {
-          result = { ok: true };
-          toolInvocations.push({ name: 'select_stat', args: { code } });
-        } else {
-          result = { ok: false, error: 'Unknown code' };
-        }
-        convo.push({
-          role: 'tool',
-          content: JSON.stringify(result),
-          tool_call_id: call.id,
-        });
-      }
-    }
-  }
-
-  const { year = '2023', dataset = 'acs/acs5' } = config || {};
-
+async function runModel(
+  model: string,
+  convo: Message[],
+  stats: Array<{ code: string; description: string; data?: unknown }> = [],
+  year: string,
+  dataset: string
+) {
   const tools = [
     {
       type: 'function',
@@ -113,19 +74,38 @@ export async function POST(req: NextRequest) {
         },
       },
     },
+    {
+      type: 'function',
+      function: {
+        name: 'load_stat',
+        description: 'Load a stored statistic by code.',
+        parameters: {
+          type: 'object',
+          properties: {
+            code: { type: 'string', description: 'Statistic code' },
+          },
+          required: ['code'],
+        },
+      },
+    },
   ];
 
-  const convo: Message[] = [...messages];
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+  let lastSearch: CensusVariable[] | null = null;
+  let lastSearchEmpty = false;
 
   while (true) {
     const response = await callOpenRouter({
-      model: 'openai/gpt-5-mini',
-      messages: convo,
+      model,
+      messages: [
+        { role: 'system', content: 'Respond concisely in plain text with no markdown.' },
+        ...convo,
+      ],
       tools,
       tool_choice: 'auto',
-      reasoning: { effort: "low" },
-      text: { verbosity: "low" },
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+      max_output_tokens: 100,
     });
 
     const message = response.choices?.[0]?.message;
@@ -136,10 +116,7 @@ export async function POST(req: NextRequest) {
       if (message && 'reasoning' in (message as Record<string, unknown>)) {
         delete (message as Record<string, unknown>).reasoning;
       }
-      return NextResponse.json({
-        message,
-        toolInvocations,
-      });
+      return { message, toolInvocations, lastSearchEmpty };
     }
 
     for (const call of toolCalls) {
@@ -147,14 +124,31 @@ export async function POST(req: NextRequest) {
       const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
       let result: unknown;
       if (name === 'search_census') {
-        result = await searchCensus(args.query as string, year, dataset);
+        const searchResults = await searchCensus(args.query as string, year, dataset);
+        lastSearch = searchResults;
+        lastSearchEmpty = searchResults.length === 0;
+        result = searchResults;
       } else if (name === 'add_metric') {
         const id = args.id as string;
-        if (await validateVariableId(id, year, dataset)) {
+        const match = lastSearch?.find((v) => v.id === id);
+        if (!match) {
+          result = { ok: false, error: 'id not in recent search results' };
+        } else if (await validateVariableId(id, year, dataset)) {
           result = { ok: true };
-          toolInvocations.push({ name, args });
+          toolInvocations.push({ name, args: { id, label: match.label } });
+          lastSearch = null;
+          lastSearchEmpty = false;
         } else {
           result = { ok: false, error: 'Unknown variable id' };
+        }
+      } else if (name === 'load_stat') {
+        const code = args.code as string;
+        const stat = stats.find((s) => s.code === code);
+        if (stat) {
+          result = { ok: true, stat };
+          toolInvocations.push({ name, args: { code } });
+        } else {
+          result = { ok: false, error: 'Unknown code' };
         }
       }
       convo.push({
@@ -166,3 +160,63 @@ export async function POST(req: NextRequest) {
   }
 }
 
+export async function POST(req: NextRequest) {
+  const { messages, config, stats } = await req.json();
+  const { year = '2023', dataset = 'acs/acs5' } = config || {};
+  const lastUser = [...messages]
+    .reverse()
+    .find((m: Message) => m.role === 'user')?.content || '';
+
+  const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+
+  const ids = parseMetricIds(lastUser);
+  if (ids.length) {
+    const added: string[] = [];
+    for (const id of ids) {
+      if (await validateVariableId(id, year, dataset)) {
+        const info = await getVariableById(id, year, dataset);
+        const label = info?.label || id;
+        toolInvocations.push({ name: 'add_metric', args: { id, label } });
+        added.push(label);
+      }
+    }
+    const content = added.length
+      ? `Added ${added.join(', ')} to your metrics list.`
+      : 'No valid Census variable ids found.';
+    return NextResponse.json({
+      message: { role: 'assistant', content },
+      toolInvocations,
+    });
+  }
+
+  const action = parseActionQuery(lastUser);
+  if (action) {
+    const results = await searchCensus(action, year, dataset);
+    if (results.length) {
+      const best = results[0];
+      toolInvocations.push({ name: 'add_metric', args: { id: best.id, label: best.label } });
+      return NextResponse.json({
+        message: {
+          role: 'assistant',
+          content: `Added "${best.label}" to your metrics list.`,
+        },
+        toolInvocations,
+      });
+    }
+    // fall through to full chat if not found
+  }
+
+  const convo: Message[] = [...messages];
+  const first = await runModel('openai/gpt-oss-120b:nitro', convo, stats, year, dataset);
+  toolInvocations.push(...first.toolInvocations);
+  if (first.lastSearchEmpty) {
+    convo.push({
+      role: 'assistant',
+      content: "The data we are considering is not found, I'm going to search deeper.",
+    });
+    const deeper = await runModel('openai/gpt-5-mini', convo, stats, year, dataset);
+    toolInvocations.push(...deeper.toolInvocations);
+    return NextResponse.json({ message: deeper.message, toolInvocations });
+  }
+  return NextResponse.json({ message: first.message, toolInvocations });
+}

--- a/app/logs/page.tsx
+++ b/app/logs/page.tsx
@@ -6,6 +6,7 @@ import NavBar from '../../components/NavBar';
 interface LogEntry {
   id: number;
   timestamp: number;
+  summary: string;
   service: string;
   direction: 'request' | 'response';
   message: unknown;
@@ -52,6 +53,7 @@ export default function LogsPage() {
                   : 'bg-blue-100 text-blue-800 ml-8'
               }`}
             >
+              <div className="text-xs font-medium mb-1">{log.summary}</div>
               <div className="text-xs text-gray-500 mb-1">
                 {log.service} {log.direction} {new Date(log.timestamp).toLocaleTimeString()}
               </div>

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -22,15 +22,14 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [mode, setMode] = useState<'user' | 'admin'>('user');
+  const [showSettings, setShowSettings] = useState(false);
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
-  const { metrics, clearMetrics } = useMetrics();
+  const { clearMetrics } = useMetrics();
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const CHAT_STORAGE_KEY = 'censusChatMessages';
-  const MODE_STORAGE_KEY = 'censusChatMode';
 
   useEffect(() => {
     const stored = localStorage.getItem(CHAT_STORAGE_KEY);
@@ -40,10 +39,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
       } catch {
         /* ignore */
       }
-    }
-    const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-    if (storedMode === 'user' || storedMode === 'admin') {
-      setMode(storedMode);
     }
   }, []);
 
@@ -60,10 +55,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
       el.scrollTop = el.scrollHeight;
     });
   }, [messages, loading]);
-
-  useEffect(() => {
-    localStorage.setItem(MODE_STORAGE_KEY, mode);
-  }, [mode]);
 
   // Auto-resize input area based on content
   useEffect(() => {
@@ -86,79 +77,36 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
       setMessages(newMessages);
       setInput('');
 
-      if (mode === 'admin') {
-        setLoading(true);
-        const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
-        const res = await fetch('/api/chat', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
-            config,
-          }),
-        });
-        const data = await res.json();
-        setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
-        setLoading(false);
+      setLoading(true);
+      const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}. Respond concisely in plain text with no markdown.`;
+      const stats = (statData?.stats || []) as Stat[];
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
+          config,
+          stats: stats.map(s => ({
+            code: s.code,
+            description: s.description,
+            data: JSON.parse(s.data),
+          })),
+        }),
+      });
+      const data = await res.json();
+      setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
+      setLoading(false);
 
-        if (data.toolInvocations) {
-          for (const inv of data.toolInvocations) {
-            if (inv.name === 'add_metric') {
-              await onAddMetric(inv.args);
-            }
-          }
-        }
-      } else {
-        setLoading(true);
-        const stats = (statData?.stats || []) as Stat[];
-        const isAction = /\b(add|show|map)\b/i.test(userMessage.content);
-        if (isAction) {
-          const res = await fetch('/api/chat', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              messages: [userMessage],
-              mode: 'user',
-              stats: stats.map(s => ({ code: s.code, description: s.description })),
-            }),
-          });
-          const data = await res.json();
-          setLoading(false);
-          type ToolInvocation = { name: string; args: Record<string, unknown> };
-          const inv = (data.toolInvocations as ToolInvocation[] | undefined)?.find(
-            (i) => i.name === 'select_stat'
-          );
-          if (inv && typeof inv.args.code === 'string') {
-            const code = inv.args.code as string;
-            const stat = stats.find(s => s.code === code);
+      if (data.toolInvocations) {
+        for (const inv of data.toolInvocations) {
+          if (inv.name === 'add_metric') {
+            await onAddMetric(inv.args);
+          } else if (inv.name === 'load_stat' && typeof inv.args.code === 'string') {
+            const stat = stats.find(s => s.code === inv.args.code);
             if (stat) {
               await onLoadStat(stat);
-              setMessages([...newMessages, { role: 'assistant', content: 'Added to map!' }]);
-            } else {
-              setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
             }
-          } else {
-            setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
           }
-        } else {
-          const activeStats = stats.filter(s =>
-            metrics.some(m => m.id === s.code)
-          );
-          const res = await fetch('/api/insight', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              messages: newMessages,
-              stats: activeStats.map(s => ({
-                code: s.code,
-                description: s.description,
-                data: JSON.parse(s.data),
-              })),
-            }),
-          });
-          const data = await res.json();
-          setLoading(false);
-          setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
         }
       }
     };
@@ -176,54 +124,18 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
                 add map data &amp; chat
               </div>
             </span>
-            <div
-              className="relative"
-              style={{ display: 'inline-block' }}
-            >
-              <select
-                className="border transition-colors pr-8"
-                style={{
-                  paddingTop: 'var(--spacing-2)',
-                  paddingBottom: 'var(--spacing-2)',
-                  paddingLeft: 'var(--spacing-4)',
-                  paddingRight: 'var(--spacing-10)', // extra right padding for chevron
-                  borderRadius: 'var(--radius-field)', // 8px
-                  backgroundColor: 'var(--color-base-100)',
-                  color: 'var(--color-base-content)',
-                  borderColor: 'var(--color-base-300)',
-                  fontSize: 'var(--font-size-sm)', // 14px
-                  appearance: 'none',
-                  WebkitAppearance: 'none',
-                  MozAppearance: 'none',
-                }}
-                value={mode}
-                onChange={e => setMode(e.target.value as 'user' | 'admin')}
-              >
-                <option value="user">User Mode</option>
-                <option value="admin">Admin Mode</option>
-              </select>
-              {/* Down chevron icon, with right padding */}
-              <span
-                className="pointer-events-none absolute inset-y-0 right-0 flex items-center"
-                style={{ paddingRight: 'var(--spacing-3)' }}
-              >
-                <svg
-                  className="w-2 h-2 text-gray-400"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                </svg>
-              </span>
-            </div>
             <button
               onClick={clearChat}
               className="px-2 py-1 border rounded text-xs text-gray-600"
               aria-label="Clear chat"
             >
               Clear
+            </button>
+            <button
+              onClick={() => setShowSettings((s) => !s)}
+              className="text-xs text-blue-600 underline"
+            >
+              {showSettings ? 'Hide settings' : 'Show settings'}
             </button>
           </div>
           {onClose && (
@@ -238,7 +150,7 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
             </button>
           )}
         </div>
-        {mode === 'admin' && <ConfigControls />}
+        {showSettings && <ConfigControls />}
         <div
           ref={scrollContainerRef}
           className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100"
@@ -275,7 +187,7 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
                 sendMessage();
               }
             }}
-            placeholder={mode === 'admin' ? 'Ask about US Census stats... (Shift+Enter for newline)' : 'Search stored stats...'}
+              placeholder={'Ask about US Census stats... (Shift+Enter for newline)'}
           />
           {/* Hide scrollbar for Webkit browsers */}
           <style jsx>{`

--- a/lib/censusQueryMap.ts
+++ b/lib/censusQueryMap.ts
@@ -15,4 +15,7 @@ export const COMMON_QUERY_MAP: Record<string, CensusVariableInfo> = {
   'total population': find('B01003_001E'),
   population: find('B01003_001E'),
   'per capita income': find('B19301_001E'),
+  'latino population': find('B03003_003E'),
+  'hispanic population': find('B03003_003E'),
+  'hispanic or latino population': find('B03003_003E'),
 };

--- a/lib/censusTools.ts
+++ b/lib/censusTools.ts
@@ -2,6 +2,8 @@ import { addLog } from './logStore';
 import { CURATED_VARIABLES } from './censusVariables';
 import { COMMON_QUERY_MAP } from './censusQueryMap';
 
+const STOP_WORDS = new Set(['and', 'or', 'of', 'the', 'in', 'for', 'population']);
+
 export interface CensusVariable {
   id: string;
   label: string;
@@ -40,6 +42,18 @@ export async function validateVariableId(id: string, year: string, dataset: stri
   return vars.some(([vid]) => vid === id);
 }
 
+export async function getVariableById(
+  id: string,
+  year: string,
+  dataset: string
+): Promise<CensusVariable | null> {
+  const vars = await loadVariables(year, dataset);
+  const match = vars.find(([vid]) => vid === id);
+  if (!match) return null;
+  const [, info] = match;
+  return { id, label: info.label, concept: info.concept };
+}
+
 export async function searchCensus(
   query: string,
   year: string,
@@ -56,7 +70,9 @@ export async function searchCensus(
     return result;
   }
 
-  const tokens = q.split(/\s+/);
+  const tokens = q
+    .split(/\s+/)
+    .filter((t) => t && !STOP_WORDS.has(t));
   const curated = CURATED_VARIABLES.filter((v) =>
     tokens.every(
       (t) =>
@@ -77,7 +93,9 @@ export async function searchCensus(
     message: { type: 'search', query, year, dataset },
   });
   const results = vars
-    .filter(([, info]) => info.label.toLowerCase().includes(q))
+    .filter(([, info]) =>
+      tokens.every((t) => info.label.toLowerCase().includes(t))
+    )
     .slice(0, 5)
     .map(([id, info]) => ({ id, label: info.label, concept: info.concept }));
   searchCache.set(cacheKey, results);

--- a/lib/censusVariables.ts
+++ b/lib/censusVariables.ts
@@ -24,4 +24,10 @@ export const CURATED_VARIABLES: CensusVariableInfo[] = [
     concept: 'INCOME IN THE PAST 12 MONTHS (IN 2023 INFLATION-ADJUSTED DOLLARS)',
     keywords: ['per', 'capita', 'income'],
   },
+  {
+    id: 'B03003_003E',
+    label: 'Hispanic or Latino population',
+    concept: 'Hispanic or Latino Origin',
+    keywords: ['hispanic', 'latino'],
+  },
 ];

--- a/lib/logStore.ts
+++ b/lib/logStore.ts
@@ -1,6 +1,7 @@
 export interface LogEntry {
   id: number;
   timestamp: number;
+  summary: string;
   service: string;
   direction: 'request' | 'response';
   message: unknown;
@@ -9,8 +10,43 @@ export interface LogEntry {
 const logs: LogEntry[] = [];
 let nextId = 1;
 
-export function addLog(entry: Omit<LogEntry, 'id' | 'timestamp'>) {
-  logs.push({ id: nextId++, timestamp: Date.now(), ...entry });
+function summarize(
+  service: string,
+  direction: 'request' | 'response',
+  message: unknown
+): string {
+  const msg = message as Record<string, unknown>;
+  if (service === 'US Census') {
+    if (direction === 'request') {
+      if (msg?.type === 'search' && typeof msg?.query === 'string') {
+        return `US Census search "${msg.query}"`;
+      }
+      if (msg?.type === 'metric' && typeof msg?.variable === 'string') {
+        return `US Census metric ${msg.variable}`;
+      }
+      return 'US Census request';
+    }
+    if (Array.isArray(message)) {
+      return `US Census search results (${message.length})`;
+    }
+    if (msg?.type === 'metric' && typeof msg?.variable === 'string') {
+      return `US Census metric result ${msg.variable}`;
+    }
+    return 'US Census response';
+  }
+  if (service === 'OpenRouter') {
+    if (direction === 'request') {
+      const model = typeof msg?.model === 'string' ? msg.model : 'request';
+      return `OpenRouter ${model}`;
+    }
+    return 'OpenRouter response';
+  }
+  return `${service} ${direction}`;
+}
+
+export function addLog(entry: Omit<LogEntry, 'id' | 'timestamp' | 'summary'>) {
+  const summary = summarize(entry.service, entry.direction, entry.message);
+  logs.push({ id: nextId++, timestamp: Date.now(), summary, ...entry });
 }
 
 export function getLogs() {


### PR DESCRIPTION
## Summary
- attach short programmatic summaries to each log entry and display them in the logs view
- add a toggleable settings link to the chat so ConfigControls stay hidden until needed
- instruct all model calls to answer in terse plain text without markdown

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a88dd3df64832db39b0a0ff4febc0f