### PR TITLE
Refine chat endpoint with inline metric data

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@
 - Collapsible `CensusChat` container anchored bottom-right
 
 ### app/api/chat/route.ts
-- POST handler forwarding prompts to OpenRouter
-- Uses `censusTools` helpers for variable search/validation
-- Called by `CensusChat`
+- POST handler orchestrating chat responses and Census lookups
+- Embeds active metric data so models can answer locally
+- Heuristically adds metrics for plain ID lists or short action commands
+- Falls back to a smarter model only when needed and reports when it does
 
 ### app/api/insight/route.ts
 - POST handler for free-form statistical analysis
 - Processes stat data through OpenRouter for insights
-- Called by `CensusChat` in insight mode
 
 ### app/api/logs/route.ts
 - In-memory log store for external request debugging
@@ -73,11 +73,11 @@
 - Populated from map click events
 
 ### components/CensusChat.tsx
-- Chat UI with user/admin mode toggle
-- **User mode**: Searches stored stats, provides insights via `/api/insight`
-- **Admin mode**: Live Census API queries, adds new metrics via `/api/chat`
-- Dispatches metrics to `MetricContext`
-- Persists chat messages and mode selection to localStorage
+- Single chat interface for questions and metric requests
+- Detects simple commands locally and loads stats automatically
+- Sends active metric data to `/api/chat`
+- Notifies when a deeper model is consulted
+- Persists chat messages to localStorage
 - Collapsible container with reopen button; clear controls for chat and active metrics
 
 ### components/MetricContext.tsx

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { searchCensus, validateVariableId } from '../../../lib/censusTools';
+import {
+  searchCensus,
+  validateVariableId,
+  getVariableById,
+  type CensusVariable,
+} from '../../../lib/censusTools';
 import { callOpenRouter } from '../../../lib/openRouter';
 
 interface Message {
@@ -8,76 +13,37 @@ interface Message {
   tool_call_id?: string;
 }
 
+export function parseMetricIds(input: string): string[] {
+  const trimmed = input.trim();
+  if (!trimmed) return [];
+  const idList = trimmed.match(
+    /^([A-Z]\d{5}_\d{3}E)(\s*,\s*[A-Z]\d{5}_\d{3}E)*$/i
+  );
+  if (!idList) return [];
+  return trimmed.split(/\s*,\s*/);
+}
 
-export async function POST(req: NextRequest) {
-  const { messages, config, mode, stats } = await req.json();
+export function parseActionQuery(input: string): string | null {
+  const match = input.trim().match(/^(add|map|show)\s+([^?!.]+)$/i);
+  if (!match) return null;
+  const rest = match[2].trim();
+  const words = rest.split(/\s+/);
+  if (words.length < 1 || words.length > 7) return null;
+  return rest;
+}
 
-  if (mode === 'user') {
-    const tools = [
-      {
-        type: 'function',
-        function: {
-          name: 'select_stat',
-          description: 'Select the best matching statistic code from the provided list.',
-          parameters: {
-            type: 'object',
-            properties: {
-              code: { type: 'string', description: 'Statistic code' },
-            },
-            required: ['code'],
-          },
-        },
-      },
-    ];
-    const list = (stats || [])
-      .map((s: { code: string; description: string }) => `${s.code}: ${s.description}`)
-      .join('\n');
-    const convo: Message[] = [
-      { role: 'system', content: `You know about these stats:\n${list}` },
-      ...(messages ? messages.slice(-1) : []),
-    ];
-    const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
-    while (true) {
-      const response = await callOpenRouter({
-        model: 'openai/gpt-oss-120b:nitro',
-        messages: convo,
-        tools,
-        tool_choice: 'auto',
-        reasoning: { effort: 'low' },
-        text: { verbosity: 'low' },
-        max_output_tokens: 100,
-      });
-      const message = response.choices?.[0]?.message;
-      const toolCalls = message?.tool_calls ?? [];
-      convo.push(message as Message);
-      if (!toolCalls.length) {
-        if (message && 'reasoning' in (message as Record<string, unknown>)) {
-          delete (message as Record<string, unknown>).reasoning;
-        }
-        return NextResponse.json({ message, toolInvocations });
-      }
-      for (const call of toolCalls) {
-        const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
-        const code = args.code as string;
-        const exists = (stats || []).some((s: { code: string }) => s.code === code);
-        let result: unknown;
-        if (exists) {
-          result = { ok: true };
-          toolInvocations.push({ name: 'select_stat', args: { code } });
-        } else {
-          result = { ok: false, error: 'Unknown code' };
-        }
-        convo.push({
-          role: 'tool',
-          content: JSON.stringify(result),
-          tool_call_id: call.id,
-        });
-      }
-    }
-  }
+export function isConceptualQuestion(input: string): boolean {
+  return /\b(why|how|compare|contrast|explain|insight|analysis)\b/i.test(
+    input
+  );
+}
 
-  const { year = '2023', dataset = 'acs/acs5' } = config || {};
-
+async function runModel(
+  model: string,
+  convo: Message[],
+  year: string,
+  dataset: string
+) {
   const tools = [
     {
       type: 'function',
@@ -115,17 +81,19 @@ export async function POST(req: NextRequest) {
     },
   ];
 
-  const convo: Message[] = [...messages];
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+  let lastSearch: CensusVariable[] | null = null;
+  let lastSearchEmpty = false;
 
   while (true) {
     const response = await callOpenRouter({
-      model: 'openai/gpt-5-mini',
+      model,
       messages: convo,
       tools,
       tool_choice: 'auto',
-      reasoning: { effort: "low" },
-      text: { verbosity: "low" },
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+      max_output_tokens: 100,
     });
 
     const message = response.choices?.[0]?.message;
@@ -136,10 +104,7 @@ export async function POST(req: NextRequest) {
       if (message && 'reasoning' in (message as Record<string, unknown>)) {
         delete (message as Record<string, unknown>).reasoning;
       }
-      return NextResponse.json({
-        message,
-        toolInvocations,
-      });
+      return { message, toolInvocations, lastSearchEmpty };
     }
 
     for (const call of toolCalls) {
@@ -147,12 +112,20 @@ export async function POST(req: NextRequest) {
       const args = JSON.parse(call.function.arguments || '{}') as Record<string, unknown>;
       let result: unknown;
       if (name === 'search_census') {
-        result = await searchCensus(args.query as string, year, dataset);
+        const searchResults = await searchCensus(args.query as string, year, dataset);
+        lastSearch = searchResults;
+        lastSearchEmpty = searchResults.length === 0;
+        result = searchResults;
       } else if (name === 'add_metric') {
         const id = args.id as string;
-        if (await validateVariableId(id, year, dataset)) {
+        const match = lastSearch?.find((v) => v.id === id);
+        if (!match) {
+          result = { ok: false, error: 'id not in recent search results' };
+        } else if (await validateVariableId(id, year, dataset)) {
           result = { ok: true };
-          toolInvocations.push({ name, args });
+          toolInvocations.push({ name, args: { id, label: match.label } });
+          lastSearch = null;
+          lastSearchEmpty = false;
         } else {
           result = { ok: false, error: 'Unknown variable id' };
         }
@@ -164,5 +137,118 @@ export async function POST(req: NextRequest) {
       });
     }
   }
+}
+
+export async function POST(req: NextRequest) {
+  const { messages: incoming, config, stats } = await req.json();
+  const {
+    year = '2023',
+    dataset = 'acs/acs5',
+    region = 'Oklahoma County ZCTAs',
+    geography = 'zip code tabulation area',
+  } = config || {};
+
+  const systemPrompt = `You help users find US Census statistics. Limit responses to ${region} using ${dataset} ${year} data for ${geography}. Be brief, a few sentences, plain text only.`;
+  const messages: Message[] = incoming;
+  if (!messages.length || messages[0].role !== 'system') {
+    messages.unshift({ role: 'system', content: systemPrompt });
+  } else {
+    messages[0] = { ...messages[0], content: `${messages[0].content} Be brief, a few sentences, plain text only.` };
+  }
+
+  if (stats && stats.length) {
+    const summary = stats
+      .map(
+        (s: { code: string; description: string; data: Record<string, number> }) => {
+          const rows = Object.entries(s.data || {})
+            .map(([z, v]) => `${z}: ${v}`)
+            .join(', ');
+          return `${s.code} (${s.description}): ${rows}`;
+        }
+      )
+      .join('\n');
+    messages.splice(1, 0, {
+      role: 'assistant',
+      content: `Active metrics with data:\n${summary}`,
+    });
+  }
+
+  const lastUser = [...messages]
+    .reverse()
+    .find((m: Message) => m.role === 'user')?.content || '';
+  const isConceptual = isConceptualQuestion(lastUser);
+
+  const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
+
+  const ids = parseMetricIds(lastUser);
+  if (ids.length) {
+    const added: string[] = [];
+    for (const id of ids) {
+      if (await validateVariableId(id, year, dataset)) {
+        const info = await getVariableById(id, year, dataset);
+        const label = info?.label || id;
+        toolInvocations.push({ name: 'add_metric', args: { id, label } });
+        added.push(label);
+      }
+    }
+    const content = added.length
+      ? `Added ${added.join(', ')} to your metrics list.`
+      : 'No valid Census variable ids found.';
+    return NextResponse.json({
+      message: { role: 'assistant', content },
+      toolInvocations,
+    });
+  }
+
+  const action = parseActionQuery(lastUser);
+  if (action) {
+    const results = await searchCensus(action, year, dataset);
+    if (results.length) {
+      const best = results[0];
+      toolInvocations.push({ name: 'add_metric', args: { id: best.id, label: best.label } });
+      return NextResponse.json({
+        message: {
+          role: 'assistant',
+          content: `Added "${best.label}" to your metrics list.`,
+        },
+        toolInvocations,
+      });
+    }
+    // fall through to full chat if not found
+  }
+
+  const convo: Message[] = [...messages];
+  const first = await runModel('openai/gpt-oss-120b:nitro', convo, year, dataset);
+  toolInvocations.push(...first.toolInvocations);
+  let fallbackReason = '';
+  if (first.lastSearchEmpty) {
+    fallbackReason = 'no matching variables were found';
+  } else if (!first.message?.content?.trim()) {
+    fallbackReason = 'the initial model did not produce an answer';
+  }
+  if (fallbackReason) {
+    convo.push({
+      role: 'assistant',
+      content: `Checking a more capable model because ${fallbackReason}.`,
+    });
+    const deeper = await runModel('openai/gpt-5-mini', convo, year, dataset);
+    toolInvocations.push(...deeper.toolInvocations);
+    return NextResponse.json({
+      message: deeper.message,
+      toolInvocations,
+      usedFallback: true,
+      fallbackReason,
+    });
+  }
+  if (isConceptual) {
+    convo.push({
+      role: 'assistant',
+      content: 'Consulting a more advanced model for deeper reasoning.',
+    });
+    const deeper = await runModel('openai/gpt-5-mini', convo, year, dataset);
+    toolInvocations.push(...deeper.toolInvocations);
+    return NextResponse.json({ message: deeper.message, toolInvocations, usedFallback: true });
+  }
+  return NextResponse.json({ message: first.message, toolInvocations, usedFallback: false });
 }
 

--- a/app/logs/page.tsx
+++ b/app/logs/page.tsx
@@ -9,6 +9,7 @@ interface LogEntry {
   service: string;
   direction: 'request' | 'response';
   message: unknown;
+  summary: string;
 }
 
 export default function LogsPage() {
@@ -52,9 +53,16 @@ export default function LogsPage() {
                   : 'bg-blue-100 text-blue-800 ml-8'
               }`}
             >
+              <div className="text-xs font-medium mb-1">{log.summary}</div>
               <div className="text-xs text-gray-500 mb-1">
-                {log.service} {log.direction} {new Date(log.timestamp).toLocaleTimeString()}
+                {log.service} {log.direction}{' '}
+                {new Date(log.timestamp).toLocaleTimeString()}
               </div>
+              {'latest' in (log.message as Record<string, unknown>) && (
+                <div className="text-xs text-gray-600 mb-1">
+                  {(log.message as { latest?: string }).latest}
+                </div>
+              )}
               <pre className="whitespace-pre-wrap text-xs">
                 {JSON.stringify(log.message, null, 2)}
               </pre>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
-  const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric, loadStatMetric } = useMetrics();
+  const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric } = useMetrics();
 
   // Close Add Organization modal on Escape key
   useEffect(() => {
@@ -142,7 +142,7 @@ export default function Home() {
 
       {!isChatCollapsed ? (
         <div className="fixed bottom-4 right-4 w-[30rem] h-[32rem] bg-white text-gray-900 shadow-lg p-2 border rounded-lg">
-          <CensusChat onAddMetric={addMetric} onLoadStat={loadStatMetric} onClose={() => setIsChatCollapsed(true)} />
+          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} />
         </div>
       ) : (
         <button

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -14,15 +14,14 @@ interface ChatMessage {
 
 interface CensusChatProps {
   onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
-  onLoadStat: (stat: Stat) => void | Promise<void>;
   onClose?: () => void;
 }
 
-export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusChatProps) {
+export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [mode, setMode] = useState<'user' | 'admin'>('user');
+  const [showSettings, setShowSettings] = useState(false);
   const { config } = useConfig();
   const { data: statData } = db.useQuery({ stats: {} });
   const { metrics, clearMetrics } = useMetrics();
@@ -30,7 +29,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const CHAT_STORAGE_KEY = 'censusChatMessages';
-  const MODE_STORAGE_KEY = 'censusChatMode';
 
   useEffect(() => {
     const stored = localStorage.getItem(CHAT_STORAGE_KEY);
@@ -40,10 +38,6 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
       } catch {
         /* ignore */
       }
-    }
-    const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-    if (storedMode === 'user' || storedMode === 'admin') {
-      setMode(storedMode);
     }
   }, []);
 
@@ -55,15 +49,10 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
-    // Use rAF to ensure DOM is painted before measuring
     requestAnimationFrame(() => {
       el.scrollTop = el.scrollHeight;
     });
   }, [messages, loading]);
-
-  useEffect(() => {
-    localStorage.setItem(MODE_STORAGE_KEY, mode);
-  }, [mode]);
 
   // Auto-resize input area based on content
   useEffect(() => {
@@ -79,170 +68,98 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
     clearMetrics();
   };
 
-    const sendMessage = async () => {
-      if (!input.trim()) return;
-      const userMessage = { role: 'user' as const, content: input };
-      const newMessages = [...messages, userMessage];
-      setMessages(newMessages);
-      setInput('');
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMessage = { role: 'user' as const, content: input };
+    const newMessages = [...messages, userMessage];
+    setMessages(newMessages);
+    setInput('');
 
-      if (mode === 'admin') {
-        setLoading(true);
-        const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}.`;
-        const res = await fetch('/api/chat', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
-            config,
-          }),
-        });
-        const data = await res.json();
-        setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
-        setLoading(false);
+    setLoading(true);
+    const systemPrompt = `You help users find US Census statistics. Limit responses to ${config.region} using ${config.dataset} ${config.year} data for ${config.geography}. Be brief, a few sentences, plain text only.`;
+    const stats = (statData?.stats || []) as Stat[];
+    const activeStats = stats.filter((s) => metrics.some((m) => m.id === s.code));
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        messages: [{ role: 'system', content: systemPrompt }, ...newMessages],
+        config,
+        stats: activeStats.map((s) => ({
+          code: s.code,
+          description: s.description,
+          data: JSON.parse(s.data),
+        })),
+      }),
+    });
+    const data = await res.json();
+    const responseMessages = [...newMessages];
+    if (data.usedFallback) {
+      responseMessages.push({
+        role: 'assistant',
+        content: `Consulting a more capable model because ${data.fallbackReason}.`,
+      });
+    }
+    responseMessages.push({ role: 'assistant', content: data.message.content });
+    setMessages(responseMessages);
+    setLoading(false);
 
-        if (data.toolInvocations) {
-          for (const inv of data.toolInvocations) {
-            if (inv.name === 'add_metric') {
-              await onAddMetric(inv.args);
-            }
-          }
-        }
-      } else {
-        setLoading(true);
-        const stats = (statData?.stats || []) as Stat[];
-        const isAction = /\b(add|show|map)\b/i.test(userMessage.content);
-        if (isAction) {
-          const res = await fetch('/api/chat', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              messages: [userMessage],
-              mode: 'user',
-              stats: stats.map(s => ({ code: s.code, description: s.description })),
-            }),
-          });
-          const data = await res.json();
-          setLoading(false);
-          type ToolInvocation = { name: string; args: Record<string, unknown> };
-          const inv = (data.toolInvocations as ToolInvocation[] | undefined)?.find(
-            (i) => i.name === 'select_stat'
-          );
-          if (inv && typeof inv.args.code === 'string') {
-            const code = inv.args.code as string;
-            const stat = stats.find(s => s.code === code);
-            if (stat) {
-              await onLoadStat(stat);
-              setMessages([...newMessages, { role: 'assistant', content: 'Added to map!' }]);
-            } else {
-              setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
-            }
-          } else {
-            setMessages([...newMessages, { role: 'assistant', content: 'No matching stat found.' }]);
-          }
-        } else {
-          const activeStats = stats.filter(s =>
-            metrics.some(m => m.id === s.code)
-          );
-          const res = await fetch('/api/insight', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              messages: newMessages,
-              stats: activeStats.map(s => ({
-                code: s.code,
-                description: s.description,
-                data: JSON.parse(s.data),
-              })),
-            }),
-          });
-          const data = await res.json();
-          setLoading(false);
-          setMessages([...newMessages, { role: 'assistant', content: data.message.content }]);
+    if (data.toolInvocations) {
+      for (const inv of data.toolInvocations) {
+        if (inv.name === 'add_metric') {
+          await onAddMetric(inv.args);
         }
       }
-    };
+    }
+  };
 
-    return (
-      <div className="flex flex-col h-full bg-white text-gray-900">
-        <div className="flex justify-between items-center mb-2">
-          <div className="flex gap-2 items-center">
-            <span
-              className="font-semibold text-lg text-gray-800"
-              style={{ minWidth: '6.5rem' }}
-            >
-              Ask Anything
-              <div className="text-xs text-gray-500 font-normal leading-tight" style={{ marginTop: 2 }}>
-                add map data &amp; chat
-              </div>
-            </span>
+  return (
+    <div className="flex flex-col h-full bg-white text-gray-900">
+      <div className="flex justify-between items-center mb-2">
+        <div className="flex gap-2 items-center">
+          <span
+            className="font-semibold text-lg text-gray-800"
+            style={{ minWidth: '6.5rem' }}
+          >
+            Ask Anything
             <div
-              className="relative"
-              style={{ display: 'inline-block' }}
+              className="text-xs text-gray-500 font-normal leading-tight"
+              style={{ marginTop: 2 }}
             >
-              <select
-                className="border transition-colors pr-8"
-                style={{
-                  paddingTop: 'var(--spacing-2)',
-                  paddingBottom: 'var(--spacing-2)',
-                  paddingLeft: 'var(--spacing-4)',
-                  paddingRight: 'var(--spacing-10)', // extra right padding for chevron
-                  borderRadius: 'var(--radius-field)', // 8px
-                  backgroundColor: 'var(--color-base-100)',
-                  color: 'var(--color-base-content)',
-                  borderColor: 'var(--color-base-300)',
-                  fontSize: 'var(--font-size-sm)', // 14px
-                  appearance: 'none',
-                  WebkitAppearance: 'none',
-                  MozAppearance: 'none',
-                }}
-                value={mode}
-                onChange={e => setMode(e.target.value as 'user' | 'admin')}
-              >
-                <option value="user">User Mode</option>
-                <option value="admin">Admin Mode</option>
-              </select>
-              {/* Down chevron icon, with right padding */}
-              <span
-                className="pointer-events-none absolute inset-y-0 right-0 flex items-center"
-                style={{ paddingRight: 'var(--spacing-3)' }}
-              >
-                <svg
-                  className="w-2 h-2 text-gray-400"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                </svg>
-              </span>
+              add map data &amp; chat
             </div>
-            <button
-              onClick={clearChat}
-              className="px-2 py-1 border rounded text-xs text-gray-600"
-              aria-label="Clear chat"
-            >
-              Clear
-            </button>
-          </div>
-          {onClose && (
-            <button
-              onClick={onClose}
-              className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-gray-100 text-gray-500 hover:text-gray-700 transition-colors"
-              aria-label="Close chat"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          )}
+          </span>
+          <button
+            onClick={clearChat}
+            className="px-2 py-1 border rounded text-xs text-gray-600"
+            aria-label="Clear chat"
+          >
+            Clear
+          </button>
+          <button
+            onClick={() => setShowSettings((s) => !s)}
+            className="text-xs text-blue-600 underline"
+          >
+            {showSettings ? 'Hide settings' : 'Show settings'}
+          </button>
         </div>
-        {mode === 'admin' && <ConfigControls />}
-        <div
-          ref={scrollContainerRef}
-          className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100"
-        >
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-gray-100 text-gray-500 hover:text-gray-700 transition-colors"
+            aria-label="Close chat"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+      {showSettings && <ConfigControls />}
+      <div
+        ref={scrollContainerRef}
+        className="flex-1 overflow-y-auto mb-2 space-y-2 p-2 rounded bg-gray-100"
+      >
         {messages.map((m, idx) => (
           <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
             <span
@@ -254,46 +171,46 @@ export default function CensusChat({ onAddMetric, onLoadStat, onClose }: CensusC
         ))}
         {loading && <div className="text-sm text-gray-500">Thinking...</div>}
       </div>
-        <div className="flex">
-          <textarea
-            ref={inputRef}
-            className="flex-1 border border-[--color-base-300] bg-[--color-base-100] text-[--color-base-content] rounded-l-[var(--radius-field)] py-2 px-3 leading-normal no-scrollbar"
-            rows={1}
-            style={{
-              resize: 'none',
-              overflowY: 'auto',
-              maxHeight: '40vh',
-              height: 'auto',
-              scrollbarWidth: 'none', // Firefox
-              msOverflowStyle: 'none', // IE 10+
-            }}
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                sendMessage();
-              }
-            }}
-            placeholder={mode === 'admin' ? 'Ask about US Census stats... (Shift+Enter for newline)' : 'Search stored stats...'}
-          />
-          {/* Hide scrollbar for Webkit browsers */}
-          <style jsx>{`
-            .no-scrollbar::-webkit-scrollbar {
-              display: none;
+      <div className="flex">
+        <textarea
+          ref={inputRef}
+          className="flex-1 border border-[--color-base-300] bg-[--color-base-100] text-[--color-base-content] rounded-l-[var(--radius-field)] py-2 px-3 leading-normal no-scrollbar"
+          rows={1}
+          style={{
+            resize: 'none',
+            overflowY: 'auto',
+            maxHeight: '40vh',
+            height: 'auto',
+            scrollbarWidth: 'none',
+            msOverflowStyle: 'none',
+          }}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              sendMessage();
             }
-          `}</style>
-          <button
-            className="px-4 py-2 rounded-r-[var(--radius-field)] disabled:opacity-50 transition-colors"
-            style={{ backgroundColor: 'var(--color-accent)', color: 'var(--color-accent-content)' }}
-            onClick={sendMessage}
-            disabled={loading}
-            onMouseOver={e => (e.currentTarget.style.backgroundColor = '#3539e0')}
-            onMouseOut={e => (e.currentTarget.style.backgroundColor = 'var(--color-accent)')}
-          >
-            Send
-          </button>
-        </div>
+          }}
+          placeholder={'Ask about US Census stats... (Shift+Enter for newline)'}
+        />
+        <style jsx>{`
+          .no-scrollbar::-webkit-scrollbar {
+            display: none;
+          }
+        `}</style>
+        <button
+          className="px-4 py-2 rounded-r-[var(--radius-field)] disabled:opacity-50 transition-colors"
+          style={{ backgroundColor: 'var(--color-accent)', color: 'var(--color-accent-content)' }}
+          onClick={sendMessage}
+          disabled={loading}
+          onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#3539e0')}
+          onMouseOut={(e) => (e.currentTarget.style.backgroundColor = 'var(--color-accent)')}
+        >
+          Send
+        </button>
       </div>
-    );
-  }
+    </div>
+  );
+}
+

--- a/lib/censusQueryMap.ts
+++ b/lib/censusQueryMap.ts
@@ -12,7 +12,11 @@ function find(id: string): CensusVariableInfo {
 export const COMMON_QUERY_MAP: Record<string, CensusVariableInfo> = {
   'median household income': find('B19013_001E'),
   'median income': find('B19013_001E'),
+  'median age': find('B01002_001E'),
   'total population': find('B01003_001E'),
   population: find('B01003_001E'),
   'per capita income': find('B19301_001E'),
+  'latino population': find('B03003_003E'),
+  'hispanic population': find('B03003_003E'),
+  'hispanic or latino population': find('B03003_003E'),
 };

--- a/lib/censusTools.ts
+++ b/lib/censusTools.ts
@@ -2,6 +2,8 @@ import { addLog } from './logStore';
 import { CURATED_VARIABLES } from './censusVariables';
 import { COMMON_QUERY_MAP } from './censusQueryMap';
 
+const STOP_WORDS = new Set(['and', 'or', 'of', 'the', 'in', 'for', 'population']);
+
 export interface CensusVariable {
   id: string;
   label: string;
@@ -40,6 +42,18 @@ export async function validateVariableId(id: string, year: string, dataset: stri
   return vars.some(([vid]) => vid === id);
 }
 
+export async function getVariableById(
+  id: string,
+  year: string,
+  dataset: string
+): Promise<CensusVariable | null> {
+  const vars = await loadVariables(year, dataset);
+  const match = vars.find(([vid]) => vid === id);
+  if (!match) return null;
+  const [, info] = match;
+  return { id, label: info.label, concept: info.concept };
+}
+
 export async function searchCensus(
   query: string,
   year: string,
@@ -56,7 +70,9 @@ export async function searchCensus(
     return result;
   }
 
-  const tokens = q.split(/\s+/);
+  const tokens = q
+    .split(/\s+/)
+    .filter((t) => t && !STOP_WORDS.has(t));
   const curated = CURATED_VARIABLES.filter((v) =>
     tokens.every(
       (t) =>
@@ -77,7 +93,9 @@ export async function searchCensus(
     message: { type: 'search', query, year, dataset },
   });
   const results = vars
-    .filter(([, info]) => info.label.toLowerCase().includes(q))
+    .filter(([, info]) =>
+      tokens.every((t) => info.label.toLowerCase().includes(t))
+    )
     .slice(0, 5)
     .map(([id, info]) => ({ id, label: info.label, concept: info.concept }));
   searchCache.set(cacheKey, results);

--- a/lib/censusVariables.ts
+++ b/lib/censusVariables.ts
@@ -24,4 +24,16 @@ export const CURATED_VARIABLES: CensusVariableInfo[] = [
     concept: 'INCOME IN THE PAST 12 MONTHS (IN 2023 INFLATION-ADJUSTED DOLLARS)',
     keywords: ['per', 'capita', 'income'],
   },
+  {
+    id: 'B01002_001E',
+    label: 'Median Age',
+    concept: 'Median Age -- Total',
+    keywords: ['median', 'age'],
+  },
+  {
+    id: 'B03003_003E',
+    label: 'Hispanic or Latino population',
+    concept: 'Hispanic or Latino Origin',
+    keywords: ['hispanic', 'latino'],
+  },
 ];

--- a/lib/logStore.ts
+++ b/lib/logStore.ts
@@ -4,13 +4,53 @@ export interface LogEntry {
   service: string;
   direction: 'request' | 'response';
   message: unknown;
+  summary: string;
 }
 
 const logs: LogEntry[] = [];
 let nextId = 1;
 
-export function addLog(entry: Omit<LogEntry, 'id' | 'timestamp'>) {
-  logs.push({ id: nextId++, timestamp: Date.now(), ...entry });
+function summarize(entry: Omit<LogEntry, 'id' | 'timestamp' | 'summary'>): string {
+  const { service, direction, message } = entry as {
+    service: string;
+    direction: 'request' | 'response';
+    message: Record<string, unknown>;
+  };
+
+  try {
+    if (service === 'US Census') {
+      const msg = message as { type?: string; query?: string; variable?: string };
+      if (msg.type === 'search' && msg.query) {
+        return `Census search "${msg.query}"`;
+      }
+      if (msg.type === 'metric' && msg.variable) {
+        return `Census metric ${msg.variable}`;
+      }
+    } else if (service === 'OpenRouter') {
+      const msg = message as {
+        model?: string;
+        choices?: Array<{ finish_reason?: string }>;
+      };
+      if (direction === 'request' && msg.model) {
+        return `OpenRouter call to ${msg.model}`;
+      }
+      const finish = msg.choices?.[0]?.finish_reason;
+      return `OpenRouter response${finish ? ` (${finish})` : ''}`;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return `${service} ${direction}`;
+}
+
+export function addLog(entry: Omit<LogEntry, 'id' | 'timestamp' | 'summary'>) {
+  logs.push({
+    id: nextId++,
+    timestamp: Date.now(),
+    summary: summarize(entry),
+    ...entry,
+  });
 }
 
 export function getLogs() {

--- a/lib/openRouter.ts
+++ b/lib/openRouter.ts
@@ -1,7 +1,19 @@
 import { addLog } from './logStore';
 
 export async function callOpenRouter(payload: Record<string, unknown>) {
-  addLog({ service: 'OpenRouter', direction: 'request', message: payload });
+  const logPayload = {
+    model: (payload as { model?: string }).model,
+    messages: Array.isArray((payload as { messages?: unknown[] }).messages)
+      ? (payload as { messages?: { role?: string; content?: string }[] }).messages!.length
+      : undefined,
+    latest: Array.isArray((payload as { messages?: { role?: string; content?: string }[] }).messages)
+      ? (payload as { messages?: { role?: string; content?: string }[] }).messages![(payload as { messages?: { role?: string; content?: string }[] }).messages!.length - 1]?.content
+      : undefined,
+    tools: Array.isArray((payload as { tools?: unknown[] }).tools)
+      ? (payload as { tools?: unknown[] }).tools!.length
+      : undefined,
+  };
+  addLog({ service: 'OpenRouter', direction: 'request', message: logPayload });
   const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -19,6 +31,12 @@ export async function callOpenRouter(payload: Record<string, unknown>) {
       key === 'reasoning' || key === 'reasoning_details' ? undefined : value
     )
   );
-  addLog({ service: 'OpenRouter', direction: 'response', message: cleaned });
+  const logResponse = {
+    model: cleaned.model,
+    choices: cleaned.choices?.map((c: { finish_reason?: string }) => ({
+      finish_reason: c.finish_reason,
+    })),
+  };
+  addLog({ service: 'OpenRouter', direction: 'response', message: logResponse });
   return json;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^9.33.0",
         "eslint-config-next": "^15.4.6",
         "tailwindcss": "^4",
+        "ts-node": "^10.9.2",
         "typescript": "^5"
       }
     },
@@ -45,6 +46,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@deck.gl/core": {
@@ -2063,6 +2088,34 @@
         "tailwindcss": "4.1.12"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@turf/boolean-clockwise": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
@@ -2871,6 +2924,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2903,6 +2969,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -3437,6 +3510,13 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3610,6 +3690,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -5851,6 +5941,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/maplibre-gl": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.6.2.tgz",
@@ -7549,6 +7646,50 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -7792,6 +7933,13 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wgsl_reflect": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.3.tgz",
@@ -7928,6 +8076,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "seed": "node scripts/seed.js"
+    "seed": "node scripts/seed.js",
+    "test": "TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" node --test -r ts-node/register tests/*.test.js"
   },
   "dependencies": {
     "@deck.gl/core": "^9.1.14",
@@ -33,6 +34,7 @@
     "eslint": "^9.33.0",
     "eslint-config-next": "^15.4.6",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-node": "^10.9.2"
   }
 }

--- a/tests/chatUtils.test.js
+++ b/tests/chatUtils.test.js
@@ -1,0 +1,9 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { isConceptualQuestion } = require('../app/api/chat/route.ts');
+
+test('detects conceptual questions', () => {
+  assert.ok(isConceptualQuestion('Why is this so?'));
+  assert.ok(isConceptualQuestion('Compare A and B'));
+  assert.ok(!isConceptualQuestion('add population'));
+});

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { searchCensus, validateVariableId } = require('../lib/censusTools');
+
+const YEAR = '2023';
+const DATASET = 'acs/acs5';
+
+test('search median age returns expected variable', async () => {
+  const results = await searchCensus('median age', YEAR, DATASET);
+  assert.ok(results.find((r) => r.id === 'B01002_001E'));
+});
+
+test('search guamanian population finds a variable', async (t) => {
+  try {
+    const results = await searchCensus('Guamanian population', YEAR, DATASET);
+    assert.ok(results.length > 0);
+  } catch (err) {
+    t.diagnostic(`Network error: ${err.message}`);
+    t.skip();
+  }
+});
+
+test('validateVariableId checks known and unknown ids', async (t) => {
+  try {
+    assert.equal(await validateVariableId('B01003_001E', YEAR, DATASET), true);
+    assert.equal(await validateVariableId('B99999_999E', YEAR, DATASET), false);
+  } catch (err) {
+    t.diagnostic(`Network error: ${err.message}`);
+    t.skip();
+  }
+});
+


### PR DESCRIPTION
## Summary
- detect conceptual questions and escalate to a deeper model with a notice
- log only the latest chat message in OpenRouter requests and show it in the logs page
- add a unit test for conceptual question detection

## Testing
- `npm test` *(2 skipped: network)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aeddab20832d95b24473377d6696