### PR TITLE
Integrate ProPublica and local organization search

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 ## Components
 ### components/OKCMap.tsx
 - Composes MapLibre map and deck.gl overlay
-- Builds layers via `createOrganizationLayer` and `createZctaMetricLayer`
+- Builds layers via `createOrganizationLayers` and `createZctaMetricLayer`
 - Emits `onOrganizationClick` callback
 
 ### components/OrganizationDetails.tsx
@@ -120,7 +120,7 @@
 - `searchCensus` and `validateVariableId` helpers
 
 ### lib/mapLayers.ts
-- `createOrganizationLayer` for point markers
+- `createOrganizationLayers` for point markers and highlighted pins
 - `createZctaMetricLayer` for choropleth metrics
 - Pure functions returning deck.gl layers
 

--- a/app/api/geocode/route.ts
+++ b/app/api/geocode/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse, NextRequest } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q') ?? '';
+  if (!q) {
+    return NextResponse.json({ error: 'Missing q' }, { status: 400 });
+  }
+  try {
+    const upstream = await fetch(
+      `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(q)}`,
+      {
+        headers: { 'User-Agent': 'NEProto' },
+      }
+    );
+    const data = await upstream.json();
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: 'Failed to geocode' }, { status: 500 });
+  }
+}

--- a/app/api/propublica/organizations/[ein]/route.ts
+++ b/app/api/propublica/organizations/[ein]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse, NextRequest } from 'next/server';
+import { addLog } from '../../../../../lib/logStore';
+
+export async function GET(req: NextRequest) {
+  const segments = req.nextUrl.pathname.split('/');
+  const ein = segments[segments.length - 1];
+  try {
+    addLog({
+      service: 'ProPublica',
+      direction: 'request',
+      message: { type: 'organization', ein },
+    });
+    const upstream = await fetch(
+      `https://projects.propublica.org/nonprofits/api/v2/organizations/${ein}.json`
+    );
+    const data = await upstream.json();
+    addLog({ service: 'ProPublica', direction: 'response', message: data });
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (error) {
+    console.error(error);
+    addLog({
+      service: 'ProPublica',
+      direction: 'response',
+      message: { error: String(error) },
+    });
+    return NextResponse.json({ error: 'Failed to fetch organization' }, { status: 500 });
+  }
+}

--- a/app/api/propublica/search/route.ts
+++ b/app/api/propublica/search/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse, NextRequest } from 'next/server';
+import { addLog } from '../../../../lib/logStore';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q') ?? '';
+  try {
+    addLog({
+      service: 'ProPublica',
+      direction: 'request',
+      message: { type: 'search', query: q },
+    });
+    const upstream = await fetch(
+      `https://projects.propublica.org/nonprofits/api/v2/search.json?q=${encodeURIComponent(q)}&state%5Bid%5D=OK`
+    );
+    const data = await upstream.json();
+    addLog({ service: 'ProPublica', direction: 'response', message: data });
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (error) {
+    console.error(error);
+    addLog({
+      service: 'ProPublica',
+      direction: 'response',
+      message: { error: String(error) },
+    });
+    return NextResponse.json({ error: 'Failed to fetch search results' }, { status: 500 });
+  }
+}

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,18 +1,22 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef, useEffect } from 'react';
 import Map from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
+import { WebMercatorViewport } from '@deck.gl/core';
 import type { Organization } from '../types/organization';
 
 import type { ZctaFeature } from '../lib/census';
-import { createOrganizationLayer, createZctaMetricLayer } from '../lib/mapLayers';
+import { createOrganizationLayers, createZctaMetricLayer } from '../lib/mapLayers';
 
 interface OKCMapProps {
   organizations: Organization[];
   onOrganizationClick?: (org: Organization) => void;
   zctaFeatures?: ZctaFeature[];
+  selectedOrgId?: string | null;
+  hoveredOrgId?: string | null;
+  onOrganizationHover?: (orgId: string | null) => void;
 }
 
 const OKC_CENTER = {
@@ -20,7 +24,7 @@ const OKC_CENTER = {
   latitude: 35.4676
 };
 
-export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures }: OKCMapProps) {
+export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures, selectedOrgId, hoveredOrgId, onOrganizationHover }: OKCMapProps) {
   const [viewState, setViewState] = useState({
     longitude: OKC_CENTER.longitude,
     latitude: OKC_CENTER.latitude,
@@ -28,18 +32,58 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
     pitch: 0,
     bearing: 0
   });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current || organizations.length === 0) return;
+
+    const lats = organizations.flatMap((o) => o.locations.map((l) => l.latitude));
+    const lons = organizations.flatMap((o) => o.locations.map((l) => l.longitude));
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLon = Math.min(...lons);
+    const maxLon = Math.max(...lons);
+
+    if (!isFinite(minLat) || !isFinite(minLon) || !isFinite(maxLat) || !isFinite(maxLon)) {
+      return;
+    }
+
+    if (minLat === maxLat && minLon === maxLon) {
+      setViewState((vs) => ({ ...vs, latitude: minLat, longitude: minLon, zoom: 12 }));
+      return;
+    }
+
+    const width = containerRef.current.clientWidth || window.innerWidth;
+    const height = containerRef.current.clientHeight || window.innerHeight;
+    const { longitude, latitude, zoom } = new WebMercatorViewport({ width, height }).fitBounds(
+      [
+        [minLon, minLat],
+        [maxLon, maxLat],
+      ],
+      { padding: 40 }
+    );
+    setViewState((vs) => ({ ...vs, longitude, latitude, zoom }));
+  }, [organizations]);
 
   const layers = useMemo(() => {
-    const layers: any[] = [createOrganizationLayer(organizations, onOrganizationClick)];
+    const layers: any[] = [
+      ...createOrganizationLayers(
+        organizations,
+        onOrganizationClick,
+        selectedOrgId,
+        hoveredOrgId,
+        onOrganizationHover ? (org) => onOrganizationHover(org ? org.id : null) : undefined
+      ),
+    ];
     const zctaLayer = createZctaMetricLayer(zctaFeatures);
     if (zctaLayer) {
       layers.unshift(zctaLayer);
     }
     return layers;
-  }, [organizations, onOrganizationClick, zctaFeatures]);
+  }, [organizations, onOrganizationClick, zctaFeatures, selectedOrgId, hoveredOrgId, onOrganizationHover]);
 
   return (
-    <div className="w-full h-full relative">
+    <div className="w-full h-full relative" ref={containerRef}>
       <DeckGL
         viewState={viewState}
         onViewStateChange={(e: any) => setViewState(e.viewState)}

--- a/components/OrgSearchSidebar.tsx
+++ b/components/OrgSearchSidebar.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import type { Organization } from '../types/organization';
+import { geocode } from '../lib/geocode';
+import { nteeToCategory, inOkcCounty } from '../lib/propublica';
+
+interface OrgSearchSidebarProps {
+  existingOrgs: Organization[];
+  onResults: (orgs: Organization[] | null) => void;
+  onSelect: (org: Organization) => void;
+  onHover: (orgId: string | null) => void;
+}
+
+interface SearchResult {
+  ein: number;
+  org: Organization;
+}
+
+interface ProPublicaSearchOrg {
+  ein: number;
+  name: string;
+  city: string;
+  state: string;
+  ntee_code?: string;
+}
+
+export default function OrgSearchSidebar({ existingOrgs, onResults, onSelect, onHover }: OrgSearchSidebarProps) {
+  const [query, setQuery] = useState('');
+  const [remoteResults, setRemoteResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const localMatches = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return [];
+    return existingOrgs.filter(
+      (org) =>
+        org.name.toLowerCase().includes(term) ||
+        org.description.toLowerCase().includes(term) ||
+        org.category.toLowerCase().includes(term)
+    );
+  }, [query, existingOrgs]);
+
+  React.useEffect(() => {
+    if (!query.trim()) return;
+    onResults([...localMatches, ...remoteResults.map((r) => r.org)]);
+  }, [localMatches, remoteResults, query, onResults]);
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) {
+      setRemoteResults([]);
+      onResults(null);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/propublica/search?q=${encodeURIComponent(query)}`);
+      const data = await res.json();
+      const orgs: ProPublicaSearchOrg[] = (data.organizations || []).slice(0, 10);
+
+      const geocoded = await Promise.all(
+        orgs.map(async (o) => {
+          const address = `${o.city}, ${o.state}`;
+          const coords = await geocode(address);
+          if (!coords) return null;
+          if (!inOkcCounty(coords.latitude, coords.longitude)) return null;
+          return {
+            ein: o.ein,
+            org: {
+              id: `search-${o.ein}`,
+              name: o.name,
+              description: '',
+              category: nteeToCategory(o.ntee_code),
+              ein: o.ein,
+              createdAt: Date.now(),
+              locations: [
+                {
+                  id: `loc-${o.ein}`,
+                  address,
+                  latitude: coords.latitude,
+                  longitude: coords.longitude,
+                  isPrimary: true,
+                },
+              ],
+            },
+          } as SearchResult;
+        })
+      );
+
+      const existingNames = new Set(existingOrgs.map((o) => o.name.toLowerCase()));
+      const existingEins = new Set(
+        existingOrgs.map((o) => o.ein).filter(Boolean) as number[]
+      );
+
+      const items = geocoded.filter(
+        (r): r is SearchResult =>
+          r !== null &&
+          (!r.ein || !existingEins.has(r.ein)) &&
+          !existingNames.has(r.org.name.toLowerCase())
+      );
+
+      setRemoteResults(items);
+      onResults([...localMatches, ...items.map((i) => i.org)]);
+    } catch (err) {
+      console.error('Search error', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSelectRemote = (item: SearchResult) => {
+    const existing = existingOrgs.find(
+      (o) => o.ein === item.ein || o.name.toLowerCase() === item.org.name.toLowerCase()
+    );
+    if (existing) {
+      onSelect(existing);
+      return;
+    }
+    onSelect(item.org);
+    const filtered = remoteResults.filter((r) => r.ein !== item.ein);
+    setRemoteResults(filtered);
+    onResults([...localMatches, ...filtered.map((r) => r.org)]);
+  };
+
+  return (
+    <aside className="w-80 bg-white border-r overflow-y-auto p-4">
+      <form onSubmit={handleSearch} className="mb-4">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            if (e.target.value.trim() === '') {
+              setRemoteResults([]);
+              onResults(null);
+            }
+          }}
+          placeholder="Search organizations"
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </form>
+      {loading && <div className="text-sm text-gray-500">Searching...</div>}
+      {localMatches.length > 0 && (
+        <div className="mb-4">
+          <h3 className="font-semibold text-gray-800 mb-2 text-sm">In Database</h3>
+          <ul>
+            {localMatches.map((org) => (
+              <li
+                key={org.id}
+                className="mb-2 cursor-pointer"
+                onClick={() => onSelect(org)}
+                onMouseEnter={() => onHover(org.id)}
+                onMouseLeave={() => onHover(null)}
+              >
+                <div className="font-medium text-gray-900">{org.name}</div>
+                <div className="text-sm text-gray-500">{org.locations[0]?.address}</div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {remoteResults.length > 0 && (
+        <div>
+          <h3 className="font-semibold text-gray-800 mb-2 text-sm">Other Results</h3>
+          <ul>
+            {remoteResults.map((r) => (
+              <li
+                key={r.ein}
+                className="mb-2 cursor-pointer"
+                onClick={() => handleSelectRemote(r)}
+                onMouseEnter={() => onHover(r.org.id)}
+                onMouseLeave={() => onHover(null)}
+              >
+                <div className="font-medium text-gray-900">{r.org.name}</div>
+                <div className="text-sm text-gray-500">{r.org.locations[0].address}</div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -13,6 +13,7 @@ const _schema = i.schema({
       name: i.string(),
       description: i.string(),
       category: i.string(),
+      ein: i.number().optional().indexed(),
       website: i.string().optional(),
       phone: i.string().optional(),
       email: i.string().optional(),

--- a/lib/census.ts
+++ b/lib/census.ts
@@ -1,21 +1,6 @@
 import type { Feature, Geometry } from 'geojson';
 import { OKC_ZCTAS } from './okcZctas';
-
-async function log(entry: {
-  service: string;
-  direction: 'request' | 'response';
-  message: unknown;
-}) {
-  try {
-    await fetch('/api/logs', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(entry),
-    });
-  } catch {
-    // ignore logging errors on client
-  }
-}
+import { log } from './logClient';
 
 export interface ZctaFeature extends Feature {
   geometry: Geometry;

--- a/lib/geocode.ts
+++ b/lib/geocode.ts
@@ -1,0 +1,11 @@
+export async function geocode(address: string): Promise<{ latitude: number; longitude: number } | null> {
+  const res = await fetch(`/api/geocode?q=${encodeURIComponent(address)}`);
+  if (!res.ok) {
+    return null;
+  }
+  const data = (await res.json()) as Array<{ lat: string; lon: string }>;
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+  return { latitude: parseFloat(data[0].lat), longitude: parseFloat(data[0].lon) };
+}

--- a/lib/logClient.ts
+++ b/lib/logClient.ts
@@ -1,0 +1,17 @@
+export interface LogEntry {
+  service: string;
+  direction: 'request' | 'response';
+  message: unknown;
+}
+
+export async function log(entry: LogEntry) {
+  try {
+    await fetch('/api/logs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(entry),
+    });
+  } catch {
+    // ignore logging errors on client
+  }
+}

--- a/lib/propublica.ts
+++ b/lib/propublica.ts
@@ -1,0 +1,138 @@
+'use client';
+
+import { id } from '@instantdb/react';
+import db from './db';
+import type { Organization } from '../types/organization';
+import { geocode } from './geocode';
+import type { OrgCategory, Location } from '../types/organization';
+import { log } from './logClient';
+
+const NTEE_CATEGORY_MAP: Record<string, OrgCategory> = {
+  A: 'Arts & Culture',
+  B: 'Education',
+  C: 'Environmental',
+  D: 'Environmental',
+  E: 'Healthcare',
+  F: 'Healthcare',
+  G: 'Healthcare',
+  H: 'Healthcare',
+  I: 'Community Development',
+  J: 'Community Development',
+  K: 'Food Security',
+  L: 'Housing & Shelter',
+  M: 'Community Development',
+  N: 'Community Development',
+  O: 'Youth Development',
+  P: 'Community Development',
+  Q: 'Community Development',
+  R: 'Community Development',
+  S: 'Community Development',
+  T: 'Community Development',
+  U: 'Community Development',
+  V: 'Community Development',
+  W: 'Community Development',
+  X: 'Community Development',
+  Y: 'Other',
+  Z: 'Other',
+};
+
+export function nteeToCategory(ntee?: string | null): OrgCategory {
+  if (!ntee) return 'Other';
+  const major = ntee.charAt(0).toUpperCase();
+  if (major === 'P' && (ntee.startsWith('P7') || ntee.startsWith('P81') || ntee.startsWith('P82') || ntee.startsWith('P83'))) {
+    return 'Senior Services';
+  }
+  return NTEE_CATEGORY_MAP[major] || 'Other';
+}
+
+export const OKC_BOUNDS = {
+  minLat: 35.3768782,
+  maxLat: 35.7259831,
+  minLng: -97.6740183,
+  maxLng: -97.1410425,
+};
+
+export function inOkcCounty(lat: number, lng: number) {
+  return (
+    lat >= OKC_BOUNDS.minLat &&
+    lat <= OKC_BOUNDS.maxLat &&
+    lng >= OKC_BOUNDS.minLng &&
+    lng <= OKC_BOUNDS.maxLng
+  );
+}
+
+export async function addOrgFromProPublica(
+  ein: number,
+  location?: Pick<Location, 'address' | 'latitude' | 'longitude'>
+): Promise<Organization | null> {
+  const res = await fetch(`/api/propublica/organizations/${ein}`);
+  if (!res.ok) {
+    return null;
+  }
+  const data = await res.json();
+  const orgData = data.organization;
+  if (!orgData) {
+    return null;
+  }
+
+  let fullAddress: string;
+  let coords: { latitude: number; longitude: number } | null = null;
+
+  if (location) {
+    fullAddress = location.address;
+    coords = { latitude: location.latitude, longitude: location.longitude };
+  } else {
+    const addressParts = [
+      orgData.address,
+      orgData.city,
+      orgData.state,
+      orgData.zipcode,
+    ].filter(Boolean);
+    fullAddress = addressParts.join(', ');
+    coords = await geocode(fullAddress);
+  }
+
+  if (!coords || !inOkcCounty(coords.latitude, coords.longitude)) {
+    return null;
+  }
+
+  const orgId = id();
+  const locId = id();
+  const tx = [
+    db.tx.organizations[orgId].update({
+      name: orgData.name,
+      description: `NTEE ${orgData.ntee_code || 'Unknown'}`,
+      category: nteeToCategory(orgData.ntee_code),
+      ein: orgData.ein,
+      createdAt: Date.now(),
+    }),
+    db.tx.locations[locId]
+      .update({
+        address: fullAddress,
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+        isPrimary: true,
+      })
+      .link({ organization: orgId }),
+  ];
+  await log({ service: 'InstantDB', direction: 'request', message: tx });
+  await db.transact(tx);
+  await log({ service: 'InstantDB', direction: 'response', message: { organization: orgId } });
+  return {
+    id: orgId,
+    name: orgData.name,
+    description: `NTEE ${orgData.ntee_code || 'Unknown'}`,
+    category: nteeToCategory(orgData.ntee_code),
+    ein: orgData.ein,
+    createdAt: Date.now(),
+    locations: [
+      {
+        id: locId,
+        address: fullAddress,
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+        isPrimary: true,
+      },
+    ],
+  };
+}

--- a/types/organization.ts
+++ b/types/organization.ts
@@ -3,6 +3,7 @@ export interface Organization {
   name: string;
   description: string;
   category: string;
+  ein?: number;
   website?: string;
   phone?: string;
   email?: string;


### PR DESCRIPTION
## Summary
- de-duplicate ProPublica organization imports and reuse existing geocoded coordinates when saving to InstantDB
- streamline OrgSearchSidebar by deferring database writes to the main page handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ad8c7410832daccf229526bac0f0