### PR TITLE
feat: highlight queried zips

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,8 @@ import MetricDropdown from '../components/MetricDropdown';
 import { useMetrics } from '../components/MetricContext';
 import OrganizationDetails from '../components/OrganizationDetails';
 import type { Organization } from '../types/organization';
+import type { ZctaFeature } from '../lib/census';
+import { featuresFromZctaMap } from '../lib/census';
 
 const OKCMap = dynamic(() => import('../components/OKCMap'), {
   ssr: false,
@@ -21,6 +23,7 @@ export default function Home() {
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric } = useMetrics();
+  const [highlightFeatures, setHighlightFeatures] = useState<ZctaFeature[] | undefined>();
 
   // Close Add Organization modal on Escape key
   useEffect(() => {
@@ -77,6 +80,7 @@ export default function Home() {
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
             zctaFeatures={zctaFeatures}
+            highlightFeatures={highlightFeatures}
           />
 
           {/* Overlay metrics glass bar over the map */}
@@ -142,7 +146,18 @@ export default function Home() {
 
       {!isChatCollapsed ? (
         <div className="fixed bottom-4 right-4 w-[30rem] h-[38.4rem] bg-white text-gray-900 shadow-lg p-2 border rounded-lg">
-          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} />
+          <CensusChat
+            onAddMetric={addMetric}
+            onClose={() => setIsChatCollapsed(true)}
+            onHighlightZctas={async (zips) => {
+              const map: Record<string, number | null> = {};
+              zips.forEach((z) => {
+                map[z] = null;
+              });
+              const feats = await featuresFromZctaMap(map);
+              setHighlightFeatures(feats);
+            }}
+          />
         </div>
       ) : (
         <button

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -16,9 +16,10 @@ interface ChatMessage {
 interface CensusChatProps {
   onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
   onClose?: () => void;
+  onHighlightZctas?: (zips: string[]) => void | Promise<void>;
 }
 
-export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
+export default function CensusChat({ onAddMetric, onClose, onHighlightZctas }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -126,6 +127,10 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
   const sendMessageWith = async (text: string, mode: Mode = 'auto') => {
     if (!text.trim()) return;
     const userMessage = { role: 'user' as const, content: text };
+    const zips = text.match(/\b\d{5}\b/g);
+    if (zips && onHighlightZctas) {
+      await onHighlightZctas(Array.from(new Set(zips)));
+    }
     const newMessages = [...messages, userMessage];
 
     // Log the user message as its own log bubble

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,18 +1,20 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 import Map from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
+import { WebMercatorViewport, FlyToInterpolator } from '@deck.gl/core';
 import type { Organization } from '../types/organization';
 
 import type { ZctaFeature } from '../lib/census';
-import { createOrganizationLayer, createZctaMetricLayer } from '../lib/mapLayers';
+import { createOrganizationLayer, createZctaMetricLayer, createZctaHighlightLayer } from '../lib/mapLayers';
 
 interface OKCMapProps {
   organizations: Organization[];
   onOrganizationClick?: (org: Organization) => void;
   zctaFeatures?: ZctaFeature[];
+  highlightFeatures?: ZctaFeature[];
 }
 
 const OKC_CENTER = {
@@ -20,14 +22,53 @@ const OKC_CENTER = {
   latitude: 35.4676
 };
 
-export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures }: OKCMapProps) {
+export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures, highlightFeatures }: OKCMapProps) {
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const [viewState, setViewState] = useState({
     longitude: OKC_CENTER.longitude,
     latitude: OKC_CENTER.latitude,
     zoom: 11,
     pitch: 0,
-    bearing: 0
+    bearing: 0,
   });
+
+  useEffect(() => {
+    if (!highlightFeatures || highlightFeatures.length === 0) return;
+    const bounds = { minLon: Infinity, minLat: Infinity, maxLon: -Infinity, maxLat: -Infinity };
+    const expand = (coords: number[][]) => {
+      coords.forEach(([lon, lat]) => {
+        bounds.minLon = Math.min(bounds.minLon, lon);
+        bounds.minLat = Math.min(bounds.minLat, lat);
+        bounds.maxLon = Math.max(bounds.maxLon, lon);
+        bounds.maxLat = Math.max(bounds.maxLat, lat);
+      });
+    };
+    highlightFeatures.forEach((f) => {
+      if (f.geometry.type === 'Polygon') {
+        (f.geometry.coordinates as number[][][]).forEach((ring) => expand(ring));
+      } else if (f.geometry.type === 'MultiPolygon') {
+        (f.geometry.coordinates as number[][][][]).forEach((poly) => poly.forEach((ring) => expand(ring)));
+      }
+    });
+    const width = mapContainerRef.current?.clientWidth || window.innerWidth;
+    const height = mapContainerRef.current?.clientHeight || window.innerHeight;
+    const viewport = new WebMercatorViewport({ width, height });
+    const { longitude, latitude, zoom } = viewport.fitBounds(
+      [
+        [bounds.minLon, bounds.minLat],
+        [bounds.maxLon, bounds.maxLat],
+      ],
+      { padding: 40 }
+    );
+    setViewState((vs) => ({
+      ...vs,
+      longitude,
+      latitude,
+      zoom,
+      transitionDuration: 500,
+      transitionInterpolator: new FlyToInterpolator(),
+    }));
+  }, [highlightFeatures]);
 
   const layers = useMemo(() => {
     const layers: any[] = [createOrganizationLayer(organizations, onOrganizationClick)];
@@ -35,11 +76,15 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
     if (zctaLayer) {
       layers.unshift(zctaLayer);
     }
+    const highlightLayer = createZctaHighlightLayer(highlightFeatures);
+    if (highlightLayer) {
+      layers.unshift(highlightLayer);
+    }
     return layers;
-  }, [organizations, onOrganizationClick, zctaFeatures]);
+  }, [organizations, onOrganizationClick, zctaFeatures, highlightFeatures]);
 
   return (
-    <div className="w-full h-full relative">
+    <div ref={mapContainerRef} className="w-full h-full relative">
       <DeckGL
         viewState={viewState}
         onViewStateChange={(e: any) => setViewState(e.viewState)}

--- a/lib/mapLayers.ts
+++ b/lib/mapLayers.ts
@@ -104,3 +104,19 @@ export function createZctaMetricLayer(zctaFeatures?: ZctaFeature[]) {
     pickable: true,
   });
 }
+
+export function createZctaHighlightLayer(zctaFeatures?: ZctaFeature[]) {
+  if (!zctaFeatures || zctaFeatures.length === 0) return null;
+
+  return new GeoJsonLayer<ZctaFeature>({
+    id: 'zcta-highlight',
+    data: zctaFeatures,
+    stroked: true,
+    filled: true,
+    getFillColor: [255, 255, 0, 80],
+    getLineColor: [255, 255, 0, 200],
+    lineWidthMinPixels: 2,
+    parameters: { depthTest: false },
+    pickable: false,
+  });
+}


### PR DESCRIPTION
## Summary
- highlight requested ZIP/ZCTA boundaries and pan/zoom to them
- add deck.gl highlight layer and auto-fit view
- parse chat messages for ZIP codes and trigger highlight

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac7c0c8f44832da2bcf6e89d21e46f