### PR TITLE
Highlight ZIP codes from chat and focus map

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - Shows an immediate notice when deferring to a deeper model (so users know to wait)
 - Persists chat messages to localStorage
 - Collapsible container with reopen button; clear controls for chat and active metrics
+ - ZIP codes mentioned in chat or referenced in responses highlight on the map and center the view
 - Appends an Approach chip on assistant messages at the bottom-right of each message row; dropdown to re-run from the last user message with Auto/Fast/Smart
  - Follow-up ideas: after each assistant reply (unless the reply is a question), shows two compact, vertically stacked indigo buttons with next-step ideas — one to "Add data for …?" (avoids active/mentioned metrics) and one curiosity question from the user’s perspective. Clicking runs the relevant action; typing clears them.
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ export default function Home() {
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric } = useMetrics();
+  const [highlightedZips, setHighlightedZips] = useState<string[]>([]);
 
   // Close Add Organization modal on Escape key
   useEffect(() => {
@@ -77,6 +78,7 @@ export default function Home() {
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
             zctaFeatures={zctaFeatures}
+            highlightedZips={highlightedZips}
           />
 
           {/* Overlay metrics glass bar over the map */}
@@ -142,7 +144,11 @@ export default function Home() {
 
       {!isChatCollapsed ? (
         <div className="fixed bottom-4 right-4 w-[30rem] h-[38.4rem] bg-white text-gray-900 shadow-lg p-2 border rounded-lg">
-          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} />
+          <CensusChat
+            onAddMetric={addMetric}
+            onClose={() => setIsChatCollapsed(true)}
+            onHighlightZips={setHighlightedZips}
+          />
         </div>
       ) : (
         <button

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -16,9 +16,10 @@ interface ChatMessage {
 interface CensusChatProps {
   onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
   onClose?: () => void;
+  onHighlightZips?: (zips: string[]) => void;
 }
 
-export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
+export default function CensusChat({ onAddMetric, onClose, onHighlightZips }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -128,6 +129,11 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
     const userMessage = { role: 'user' as const, content: text };
     const newMessages = [...messages, userMessage];
 
+    const zips = text.match(/\b\d{5}\b/g);
+    if (onHighlightZips) {
+      onHighlightZips(zips ? zips : []);
+    }
+
     // Log the user message as its own log bubble
     try {
       await fetch('/api/logs', {
@@ -190,6 +196,11 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
     responseMessages.push({ role: 'assistant', content: data.message.content, modeUsed: (data.modeUsed as 'auto'|'fast'|'smart') || mode });
     setMessages(responseMessages);
     setLoading(false);
+
+    const assistantZips = data?.message?.content?.match(/\b\d{5}\b/g);
+    if (assistantZips && onHighlightZips) {
+      onHighlightZips(assistantZips);
+    }
 
     if (data.toolInvocations) {
       for (const inv of data.toolInvocations) {
@@ -276,6 +287,11 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
     responseMessages.push({ role: 'assistant', content: data.message.content, modeUsed: (data.modeUsed as 'auto'|'fast'|'smart') || mode });
     setMessages(responseMessages);
     setLoading(false);
+
+    const assistantZips = data?.message?.content?.match(/\b\d{5}\b/g);
+    if (assistantZips && onHighlightZips) {
+      onHighlightZips(assistantZips);
+    }
 
     if (data.toolInvocations) {
       for (const inv of data.toolInvocations) {

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,18 +1,21 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import Map from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
+import { GeoJsonLayer } from '@deck.gl/layers';
+import { FlyToInterpolator, WebMercatorViewport } from '@deck.gl/core';
 import type { Organization } from '../types/organization';
 
-import type { ZctaFeature } from '../lib/census';
+import { featuresFromZctaMap, type ZctaFeature } from '../lib/census';
 import { createOrganizationLayer, createZctaMetricLayer } from '../lib/mapLayers';
 
 interface OKCMapProps {
   organizations: Organization[];
   onOrganizationClick?: (org: Organization) => void;
   zctaFeatures?: ZctaFeature[];
+  highlightedZips?: string[];
 }
 
 const OKC_CENTER = {
@@ -20,7 +23,7 @@ const OKC_CENTER = {
   latitude: 35.4676
 };
 
-export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures }: OKCMapProps) {
+export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures, highlightedZips }: OKCMapProps) {
   const [viewState, setViewState] = useState({
     longitude: OKC_CENTER.longitude,
     latitude: OKC_CENTER.latitude,
@@ -29,14 +32,80 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
     bearing: 0
   });
 
+  const [highlightFeatures, setHighlightFeatures] = useState<ZctaFeature[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      if (!highlightedZips || highlightedZips.length === 0) {
+        setHighlightFeatures([]);
+        return;
+      }
+      const zctaMap: Record<string, null> = {};
+      highlightedZips.forEach((z) => { zctaMap[z] = null; });
+      const feats = await featuresFromZctaMap(zctaMap);
+      setHighlightFeatures(feats);
+
+      // Compute bounds to focus view
+      let minLng = Infinity, minLat = Infinity, maxLng = -Infinity, maxLat = -Infinity;
+      feats.forEach((f) => {
+        const geom: any = f.geometry;
+        const coords = geom.type === 'Polygon'
+          ? [geom.coordinates]
+          : geom.coordinates;
+        coords.forEach((poly: any) => {
+          poly.forEach((ring: any) => {
+            ring.forEach(([x, y]: [number, number]) => {
+              if (x < minLng) minLng = x;
+              if (x > maxLng) maxLng = x;
+              if (y < minLat) minLat = y;
+              if (y > maxLat) maxLat = y;
+            });
+          });
+        });
+      });
+      if (isFinite(minLng) && isFinite(minLat) && isFinite(maxLng) && isFinite(maxLat)) {
+        const viewport = new WebMercatorViewport({
+          width: window.innerWidth,
+          height: window.innerHeight,
+        });
+        const { longitude, latitude, zoom } = viewport.fitBounds(
+          [ [minLng, minLat], [maxLng, maxLat] ],
+          { padding: 40 }
+        );
+        setViewState((vs) => ({
+          ...vs,
+          longitude,
+          latitude,
+          zoom,
+          transitionDuration: 1000,
+          transitionInterpolator: new FlyToInterpolator(),
+        }));
+      }
+    }
+    load();
+  }, [highlightedZips]);
+
   const layers = useMemo(() => {
     const layers: any[] = [createOrganizationLayer(organizations, onOrganizationClick)];
     const zctaLayer = createZctaMetricLayer(zctaFeatures);
     if (zctaLayer) {
       layers.unshift(zctaLayer);
     }
+    if (highlightFeatures.length > 0) {
+      layers.unshift(new GeoJsonLayer({
+        id: 'highlight-zips',
+        data: highlightFeatures,
+        stroked: true,
+        filled: false,
+        getLineColor: [255, 215, 0, 200],
+        lineWidthUnits: 'meters',
+        getLineWidth: () => 200,
+        lineWidthMinPixels: 2,
+        pickable: false,
+      }));
+    }
     return layers;
-  }, [organizations, onOrganizationClick, zctaFeatures]);
+  }, [organizations, onOrganizationClick, zctaFeatures, highlightFeatures]);
 
   return (
     <div className="w-full h-full relative">


### PR DESCRIPTION
## Summary
- highlight ZIP/ZCTA boundaries mentioned in chat or assistant replies
- center and zoom map to highlighted ZIPs for better context
- document ZIP highlighting capability

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac7c0c8f44832da2bcf6e89d21e46f