### PR TITLE
Highlight ZIP codes from chat and focus map

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - Shows an immediate notice when deferring to a deeper model (so users know to wait)
 - Persists chat messages to localStorage
 - Collapsible container with reopen button; clear controls for chat and active metrics
+- Mentioning specific ZIP codes—or answers that refer to them—highlights those areas on the map and centers the view
 - Appends an Approach chip on assistant messages at the bottom-right of each message row; dropdown to re-run from the last user message with Auto/Fast/Smart
  - Follow-up ideas: after each assistant reply (unless the reply is a question), shows two compact, vertically stacked indigo buttons with next-step ideas — one to "Add data for …?" (avoids active/mentioned metrics) and one curiosity question from the user’s perspective. Clicking runs the relevant action; typing clears them.
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,12 @@ export default function Home() {
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric } = useMetrics();
+  const [highlightedZips, setHighlightedZips] = useState<string[]>([]);
+
+  const handleClearMetrics = () => {
+    clearMetrics();
+    setHighlightedZips([]);
+  };
 
   // Close Add Organization modal on Escape key
   useEffect(() => {
@@ -77,6 +83,7 @@ export default function Home() {
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
             zctaFeatures={zctaFeatures}
+            highlightedZips={highlightedZips}
           />
 
           {/* Overlay metrics glass bar over the map */}
@@ -98,7 +105,7 @@ export default function Home() {
               >
                 <MetricDropdown metrics={metrics} selected={selectedMetric} onSelect={selectMetric} />
                 <button
-                  onClick={clearMetrics}
+                  onClick={handleClearMetrics}
                   className="border transition-colors"
                   style={{
                     paddingLeft: 'var(--spacing-3)',
@@ -142,7 +149,11 @@ export default function Home() {
 
       {!isChatCollapsed ? (
         <div className="fixed bottom-4 right-4 w-[30rem] h-[38.4rem] bg-white text-gray-900 shadow-lg p-2 border rounded-lg">
-          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} />
+          <CensusChat
+            onAddMetric={addMetric}
+            onClose={() => setIsChatCollapsed(true)}
+            onHighlightZips={setHighlightedZips}
+          />
         </div>
       ) : (
         <button


### PR DESCRIPTION
## Summary
- Ensure ZIP highlight outline renders above other layers
- Limit zoom for single ZIPs and keep wider padding
- Reset highlights when chat or metrics are cleared

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac7c0c8f44832da2bcf6e89d21e46f