### PR TITLE
Highlight AI-suggested ZIPs on map

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -74,6 +74,24 @@ async function runModel(
         },
       },
     },
+    {
+      type: 'function',
+      function: {
+        name: 'highlight_zips',
+        description: 'Highlight specific ZIP codes on the map for the user.',
+        parameters: {
+          type: 'object',
+          properties: {
+            zips: {
+              type: 'array',
+              items: { type: 'string', description: '5-digit ZIP code' },
+              description: 'List of ZIP codes to emphasize on the map',
+            },
+          },
+          required: ['zips'],
+        },
+      },
+    },
   ];
 
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
@@ -132,6 +150,12 @@ async function runModel(
         } else {
           result = { ok: false, error: 'Unknown variable id' };
         }
+      } else if (name === 'highlight_zips') {
+        const zips = Array.isArray(args.zips)
+          ? (args.zips as unknown[]).map((z) => String(z))
+          : [];
+        result = { ok: true };
+        toolInvocations.push({ name, args: { zips } });
       }
       convo.push({
         role: 'tool',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
+  const [highlightZips, setHighlightZips] = useState<string[]>([]);
   const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric } = useMetrics();
 
   // Close Add Organization modal on Escape key
@@ -77,6 +78,7 @@ export default function Home() {
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
             zctaFeatures={zctaFeatures}
+            highlightedZips={highlightZips}
           />
 
           {/* Overlay metrics glass bar over the map */}
@@ -142,7 +144,7 @@ export default function Home() {
 
       {!isChatCollapsed ? (
         <div className="fixed bottom-4 right-4 w-[30rem] h-[38.4rem] bg-white text-gray-900 shadow-lg p-2 border rounded-lg">
-          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} />
+          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} onHighlightZips={setHighlightZips} />
         </div>
       ) : (
         <button

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -16,9 +16,10 @@ interface ChatMessage {
 interface CensusChatProps {
   onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
   onClose?: () => void;
+  onHighlightZips?: (zips: string[]) => void;
 }
 
-export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
+export default function CensusChat({ onAddMetric, onClose, onHighlightZips }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -99,6 +100,7 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
     localStorage.removeItem(CHAT_STORAGE_KEY);
     clearMetrics();
     setSuggestions(null);
+    onHighlightZips?.([]);
   };
 
   type Mode = 'auto' | 'fast' | 'smart';
@@ -190,6 +192,11 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
     responseMessages.push({ role: 'assistant', content: data.message.content, modeUsed: (data.modeUsed as 'auto'|'fast'|'smart') || mode });
     setMessages(responseMessages);
     setLoading(false);
+
+    if (onHighlightZips) {
+      const zips = Array.from(new Set((data.message.content.match(/\b\d{5}\b/g) || [])));
+      onHighlightZips(zips);
+    }
 
     if (data.toolInvocations) {
       for (const inv of data.toolInvocations) {

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -194,7 +194,9 @@ export default function CensusChat({ onAddMetric, onClose, onHighlightZips }: Ce
     setLoading(false);
 
     if (onHighlightZips) {
-      const zips = Array.from(new Set((data.message.content.match(/\b\d{5}\b/g) || [])));
+      const zips = Array.from(
+        new Set<string>(data.message.content.match(/\b\d{5}\b/g) ?? [])
+      );
       onHighlightZips(zips);
     }
 

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -193,17 +193,13 @@ export default function CensusChat({ onAddMetric, onClose, onHighlightZips }: Ce
     setMessages(responseMessages);
     setLoading(false);
 
-    if (onHighlightZips) {
-      const zips = Array.from(
-        new Set<string>(data.message.content.match(/\b\d{5}\b/g) ?? [])
-      );
-      onHighlightZips(zips);
-    }
-
     if (data.toolInvocations) {
       for (const inv of data.toolInvocations) {
         if (inv.name === 'add_metric') {
           await onAddMetric(inv.args);
+        } else if (inv.name === 'highlight_zips') {
+          const zips = Array.isArray(inv.args.zips) ? (inv.args.zips as string[]) : [];
+          onHighlightZips?.(zips);
         }
       }
     }
@@ -290,6 +286,9 @@ export default function CensusChat({ onAddMetric, onClose, onHighlightZips }: Ce
       for (const inv of data.toolInvocations) {
         if (inv.name === 'add_metric') {
           await onAddMetric(inv.args);
+        } else if (inv.name === 'highlight_zips') {
+          const zips = Array.isArray(inv.args.zips) ? (inv.args.zips as string[]) : [];
+          onHighlightZips?.(zips);
         }
       }
     }

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,18 +1,21 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import Map from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
 import type { Organization } from '../types/organization';
 
 import type { ZctaFeature } from '../lib/census';
-import { createOrganizationLayer, createZctaMetricLayer } from '../lib/mapLayers';
+import { createOrganizationLayer, createZctaMetricLayer, createZctaHighlightLayer } from '../lib/mapLayers';
+import { featuresFromZctaMap, type ZctaFeature } from '../lib/census';
+import { WebMercatorViewport } from '@deck.gl/core';
 
 interface OKCMapProps {
   organizations: Organization[];
   onOrganizationClick?: (org: Organization) => void;
   zctaFeatures?: ZctaFeature[];
+  highlightedZips?: string[];
 }
 
 const OKC_CENTER = {
@@ -20,7 +23,7 @@ const OKC_CENTER = {
   latitude: 35.4676
 };
 
-export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures }: OKCMapProps) {
+export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures, highlightedZips }: OKCMapProps) {
   const [viewState, setViewState] = useState({
     longitude: OKC_CENTER.longitude,
     latitude: OKC_CENTER.latitude,
@@ -28,6 +31,57 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
     pitch: 0,
     bearing: 0
   });
+  const [highlightFeatures, setHighlightFeatures] = useState<ZctaFeature[] | undefined>();
+
+  useEffect(() => {
+    const load = async () => {
+      if (!highlightedZips || highlightedZips.length === 0) {
+        setHighlightFeatures(undefined);
+        return;
+      }
+      const map: Record<string, null> = {};
+      highlightedZips.forEach((z) => {
+        map[z] = null;
+      });
+      const feats = await featuresFromZctaMap(map);
+      setHighlightFeatures(feats);
+
+      const bounds = feats.reduce(
+        (acc, f) => {
+          const coords = (f.geometry as any).coordinates;
+          const flat = (function flatten(c: any): number[][] {
+            if (typeof c[0] === 'number') return [c as number[]];
+            return c.flatMap(flatten);
+          })(coords);
+          flat.forEach(([lng, lat]) => {
+            acc[0] = Math.min(acc[0], lng);
+            acc[1] = Math.min(acc[1], lat);
+            acc[2] = Math.max(acc[2], lng);
+            acc[3] = Math.max(acc[3], lat);
+          });
+          return acc;
+        },
+        [Infinity, Infinity, -Infinity, -Infinity] as [number, number, number, number]
+      );
+
+      if (bounds[0] !== Infinity) {
+        const viewport = new WebMercatorViewport({
+          width: window.innerWidth,
+          height: window.innerHeight,
+          longitude: viewState.longitude,
+          latitude: viewState.latitude,
+          zoom: viewState.zoom,
+        });
+        const { longitude, latitude, zoom } = viewport.fitBounds(
+          [ [bounds[0], bounds[1]], [bounds[2], bounds[3]] ],
+          { padding: 40, maxZoom: viewState.zoom }
+        );
+        setViewState((v) => ({ ...v, longitude, latitude, zoom }));
+      }
+    };
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightedZips]);
 
   const layers = useMemo(() => {
     const layers: any[] = [createOrganizationLayer(organizations, onOrganizationClick)];
@@ -35,8 +89,12 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
     if (zctaLayer) {
       layers.unshift(zctaLayer);
     }
+    const highlightLayer = createZctaHighlightLayer(highlightFeatures);
+    if (highlightLayer) {
+      layers.push(highlightLayer);
+    }
     return layers;
-  }, [organizations, onOrganizationClick, zctaFeatures]);
+  }, [organizations, onOrganizationClick, zctaFeatures, highlightFeatures]);
 
   return (
     <div className="w-full h-full relative">

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -72,8 +72,8 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
           zoom: viewState.zoom,
         });
         const { longitude, latitude, zoom } = viewport.fitBounds(
-          [ [bounds[0], bounds[1]], [bounds[2], bounds[3]] ],
-          { padding: 40, maxZoom: viewState.zoom }
+          [[bounds[0], bounds[1]], [bounds[2], bounds[3]]],
+          { padding: 40, maxZoom: viewState.zoom, offset: [window.innerWidth * 0.3, 0] }
         );
         setViewState((v) => ({ ...v, longitude, latitude, zoom }));
       }

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -6,7 +6,6 @@ import Map from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
 import type { Organization } from '../types/organization';
 
-import type { ZctaFeature } from '../lib/census';
 import { createOrganizationLayer, createZctaMetricLayer, createZctaHighlightLayer } from '../lib/mapLayers';
 import { featuresFromZctaMap, type ZctaFeature } from '../lib/census';
 import { WebMercatorViewport } from '@deck.gl/core';

--- a/lib/mapLayers.ts
+++ b/lib/mapLayers.ts
@@ -104,3 +104,19 @@ export function createZctaMetricLayer(zctaFeatures?: ZctaFeature[]) {
     pickable: true,
   });
 }
+
+export function createZctaHighlightLayer(zctaFeatures?: ZctaFeature[]) {
+  if (!zctaFeatures || zctaFeatures.length === 0) return null;
+
+  return new GeoJsonLayer<ZctaFeature>({
+    id: 'zcta-highlight',
+    data: zctaFeatures,
+    stroked: true,
+    filled: false,
+    getLineColor: [215, 168, 0, 255],
+    lineWidthUnits: 'pixels',
+    lineWidthMinPixels: 4,
+    parameters: { depthTest: false },
+    pickable: false,
+  });
+}

--- a/lib/mapLayers.ts
+++ b/lib/mapLayers.ts
@@ -116,7 +116,9 @@ export function createZctaHighlightLayer(zctaFeatures?: ZctaFeature[]) {
     getLineColor: [215, 168, 0, 255],
     lineWidthUnits: 'pixels',
     lineWidthMinPixels: 4,
-    parameters: { depthTest: false },
+    // depthTest isn't in deck.gl's type defs but we want the outlines above other layers
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parameters: { depthTest: false } as any,
     pickable: false,
   });
 }


### PR DESCRIPTION
## Summary
- parse AI responses for ZIP codes and report them to the map
- draw high-visibility yellow borders around mentioned ZCTAs
- recenter map to keep highlighted ZIPs in view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae17ca3b28832d9b7ca3e22c9df3ca