### PR TITLE
feat: add derived percentage metrics

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -74,6 +74,29 @@ async function runModel(
         },
       },
     },
+    {
+      type: 'function',
+      function: {
+        name: 'add_percentage_metric',
+        description:
+          'Add a derived percentage metric combining two Census variables (numerator/denominator).',
+        parameters: {
+          type: 'object',
+          properties: {
+            numerator: {
+              type: 'string',
+              description: 'Numerator variable identifier',
+            },
+            denominator: {
+              type: 'string',
+              description: 'Denominator variable identifier',
+            },
+            label: { type: 'string', description: 'Human readable label' },
+          },
+          required: ['numerator', 'denominator', 'label'],
+        },
+      },
+    },
   ];
 
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
@@ -127,6 +150,20 @@ async function runModel(
         } else if (await validateVariableId(id, year, dataset)) {
           result = { ok: true };
           toolInvocations.push({ name, args: { id, label: match.label } });
+          lastSearch = null;
+          lastSearchEmpty = false;
+        } else {
+          result = { ok: false, error: 'Unknown variable id' };
+        }
+      } else if (name === 'add_percentage_metric') {
+        const numerator = args.numerator as string;
+        const denominator = args.denominator as string;
+        const label = args.label as string;
+        const validNum = await validateVariableId(numerator, year, dataset);
+        const validDen = await validateVariableId(denominator, year, dataset);
+        if (validNum && validDen) {
+          result = { ok: true };
+          toolInvocations.push({ name, args: { numerator, denominator, label } });
           lastSearch = null;
           lastSearchEmpty = false;
         } else {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,15 @@ export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
-  const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric } = useMetrics();
+  const {
+    metrics,
+    selectedMetric,
+    selectMetric,
+    clearMetrics,
+    zctaFeatures,
+    addMetric,
+    addPercentageMetric,
+  } = useMetrics();
 
   // Close Add Organization modal on Escape key
   useEffect(() => {
@@ -142,7 +150,11 @@ export default function Home() {
 
       {!isChatCollapsed ? (
         <div className="fixed bottom-4 right-4 w-[30rem] h-[38.4rem] bg-white text-gray-900 shadow-lg p-2 border rounded-lg">
-          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} />
+          <CensusChat
+            onAddMetric={addMetric}
+            onAddPercentMetric={addPercentageMetric}
+            onClose={() => setIsChatCollapsed(true)}
+          />
         </div>
       ) : (
         <button

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -15,10 +15,17 @@ interface ChatMessage {
 
 interface CensusChatProps {
   onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
+  onAddPercentMetric: (
+    metric: { numerator: string; denominator: string; label: string }
+  ) => void | Promise<void>;
   onClose?: () => void;
 }
 
-export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
+export default function CensusChat({
+  onAddMetric,
+  onAddPercentMetric,
+  onClose,
+}: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -195,6 +202,8 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
       for (const inv of data.toolInvocations) {
         if (inv.name === 'add_metric') {
           await onAddMetric(inv.args);
+        } else if (inv.name === 'add_percentage_metric') {
+          await onAddPercentMetric(inv.args);
         }
       }
     }
@@ -281,6 +290,8 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
       for (const inv of data.toolInvocations) {
         if (inv.name === 'add_metric') {
           await onAddMetric(inv.args);
+        } else if (inv.name === 'add_percentage_metric') {
+          await onAddPercentMetric(inv.args);
         }
       }
     }

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -33,6 +33,7 @@ const _schema = i.schema({
       source: i.string(),
       year: i.number(),
       data: i.string(),
+      details: i.string().optional(),
     }),
   },
   links: {

--- a/types/stat.ts
+++ b/types/stat.ts
@@ -7,4 +7,5 @@ export interface Stat {
   source: string;
   year: number;
   data: string;
+  details?: string;
 }


### PR DESCRIPTION
## Summary
- support `add_percentage_metric` tool in chat API
- compute and store derived percentage metrics with numerator/denominator details
- display derived stat details on stats page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae1cfb189c832dac97ee93c2645fbd