### PR TITLE
Highlight ZIP codes from chat responses

### DIFF
--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -16,9 +16,10 @@ interface ChatMessage {
 interface CensusChatProps {
   onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
   onClose?: () => void;
+  onHighlightZips?: (zips: string[]) => void | Promise<void>;
 }
 
-export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
+export default function CensusChat({ onAddMetric, onClose, onHighlightZips }: CensusChatProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -191,6 +192,9 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
     setMessages(responseMessages);
     setLoading(false);
 
+    const zips = Array.from(new Set((data.message.content.match(/\b\d{5}\b/g) || [])));
+    if (onHighlightZips) await onHighlightZips(zips);
+
     if (data.toolInvocations) {
       for (const inv of data.toolInvocations) {
         if (inv.name === 'add_metric') {
@@ -276,6 +280,9 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
     responseMessages.push({ role: 'assistant', content: data.message.content, modeUsed: (data.modeUsed as 'auto'|'fast'|'smart') || mode });
     setMessages(responseMessages);
     setLoading(false);
+
+    const zips = Array.from(new Set((data.message.content.match(/\b\d{5}\b/g) || [])));
+    if (onHighlightZips) await onHighlightZips(zips);
 
     if (data.toolInvocations) {
       for (const inv of data.toolInvocations) {

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,18 +1,20 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import Map from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
 import type { Organization } from '../types/organization';
 
 import type { ZctaFeature } from '../lib/census';
-import { createOrganizationLayer, createZctaMetricLayer } from '../lib/mapLayers';
+import { createOrganizationLayer, createZctaMetricLayer, createZctaHighlightLayer } from '../lib/mapLayers';
+import { WebMercatorViewport } from '@deck.gl/core';
 
 interface OKCMapProps {
   organizations: Organization[];
   onOrganizationClick?: (org: Organization) => void;
   zctaFeatures?: ZctaFeature[];
+  highlightedZctaFeatures?: ZctaFeature[];
 }
 
 const OKC_CENTER = {
@@ -20,7 +22,7 @@ const OKC_CENTER = {
   latitude: 35.4676
 };
 
-export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures }: OKCMapProps) {
+export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures, highlightedZctaFeatures }: OKCMapProps) {
   const [viewState, setViewState] = useState({
     longitude: OKC_CENTER.longitude,
     latitude: OKC_CENTER.latitude,
@@ -35,8 +37,36 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
     if (zctaLayer) {
       layers.unshift(zctaLayer);
     }
+    const highlightLayer = createZctaHighlightLayer(highlightedZctaFeatures);
+    if (highlightLayer) {
+      layers.push(highlightLayer);
+    }
     return layers;
-  }, [organizations, onOrganizationClick, zctaFeatures]);
+  }, [organizations, onOrganizationClick, zctaFeatures, highlightedZctaFeatures]);
+
+  useEffect(() => {
+    if (!highlightedZctaFeatures || highlightedZctaFeatures.length === 0) return;
+    let minLng = Infinity;
+    let minLat = Infinity;
+    let maxLng = -Infinity;
+    let maxLat = -Infinity;
+    const update = (coords: any): void => {
+      if (typeof coords[0] === 'number') {
+        const [lng, lat] = coords as [number, number];
+        if (lng < minLng) minLng = lng;
+        if (lng > maxLng) maxLng = lng;
+        if (lat < minLat) minLat = lat;
+        if (lat > maxLat) maxLat = lat;
+      } else {
+        coords.forEach(update);
+      }
+    };
+    highlightedZctaFeatures.forEach(f => update(f.geometry.coordinates as any));
+    const viewport = new WebMercatorViewport(viewState as any);
+    const { longitude, latitude, zoom } = viewport.fitBounds([[minLng, minLat], [maxLng, maxLat]], { padding: 40 });
+    setViewState(v => ({ ...v, longitude, latitude, zoom: Math.min(v.zoom, zoom) }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightedZctaFeatures]);
 
   return (
     <div className="w-full h-full relative">

--- a/lib/mapLayers.ts
+++ b/lib/mapLayers.ts
@@ -104,3 +104,20 @@ export function createZctaMetricLayer(zctaFeatures?: ZctaFeature[]) {
     pickable: true,
   });
 }
+
+export function createZctaHighlightLayer(zctaFeatures?: ZctaFeature[]) {
+  if (!zctaFeatures || zctaFeatures.length === 0) return null;
+
+  return new GeoJsonLayer<ZctaFeature>({
+    id: 'zcta-highlight',
+    data: zctaFeatures,
+    stroked: true,
+    filled: false,
+    getLineColor: [215, 168, 0, 255], // brand yellow
+    lineWidthUnits: 'pixels',
+    lineWidthMinPixels: 4,
+    pickable: false,
+    zIndex: 1000,
+    parameters: { depthTest: false },
+  });
+}


### PR DESCRIPTION
## Summary
- highlight map ZCTAs mentioned by assistant with thick yellow outlines
- recenter map to keep highlighted ZIPs in view
- detect ZIP codes in chat replies and trigger map highlights

## Testing
- `npm run lint`
- `npm test` (network errors caused skips)


------
https://chatgpt.com/codex/tasks/task_e_68ae17ca3b28832d9b7ca3e22c9df3ca