### PR TITLE
feat: support derived percent metrics

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -74,6 +74,23 @@ async function runModel(
         },
       },
     },
+    {
+      type: 'function',
+      function: {
+        name: 'add_percent_metric',
+        description:
+          'Add a percentage metric computed as numerator divided by denominator times 100.',
+        parameters: {
+          type: 'object',
+          properties: {
+            numerator: { type: 'string', description: 'Numerator variable id' },
+            denominator: { type: 'string', description: 'Denominator variable id' },
+            label: { type: 'string', description: 'Human readable label' },
+          },
+          required: ['numerator', 'denominator', 'label'],
+        },
+      },
+    },
   ];
 
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
@@ -129,6 +146,21 @@ async function runModel(
           toolInvocations.push({ name, args: { id, label: match.label } });
           lastSearch = null;
           lastSearchEmpty = false;
+        } else {
+          result = { ok: false, error: 'Unknown variable id' };
+        }
+      } else if (name === 'add_percent_metric') {
+        const num = args.numerator as string;
+        const den = args.denominator as string;
+        const label = args.label as string;
+        const numValid = await validateVariableId(num, year, dataset);
+        const denValid = await validateVariableId(den, year, dataset);
+        if (numValid && denValid) {
+          result = { ok: true };
+          toolInvocations.push({
+            name,
+            args: { numerator: num, denominator: den, label },
+          });
         } else {
           result = { ok: false, error: 'Unknown variable id' };
         }

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -20,12 +20,30 @@ export default function StatsPage() {
   };
 
   const handleRefresh = async (stat: Stat) => {
-    const varId = stat.code.includes('_') ? stat.code : stat.code + '_001E';
-    const features = await fetchZctaMetric(varId, { year: String(stat.year), dataset: stat.dataset });
     const zctaMap: Record<string, number | null> = {};
-    features?.forEach((f: ZctaFeature) => {
-      zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
-    });
+    if (stat.formula) {
+      const [num, den] = stat.formula.split('/');
+      const [numFeatures, denFeatures] = await Promise.all([
+        fetchZctaMetric(num, { year: String(stat.year), dataset: stat.dataset }),
+        fetchZctaMetric(den, { year: String(stat.year), dataset: stat.dataset }),
+      ]);
+      const denMap = new Map<string, number | null>();
+      denFeatures.forEach((f: ZctaFeature) => {
+        denMap.set(f.properties.ZCTA5CE10, f.properties.value ?? null);
+      });
+      numFeatures.forEach((f: ZctaFeature) => {
+        const d = denMap.get(f.properties.ZCTA5CE10);
+        const n = f.properties.value;
+        zctaMap[f.properties.ZCTA5CE10] =
+          n != null && d && d !== 0 ? (n / d) * 100 : null;
+      });
+    } else {
+      const varId = stat.code.includes('_') ? stat.code : stat.code + '_001E';
+      const features = await fetchZctaMetric(varId, { year: String(stat.year), dataset: stat.dataset });
+      features?.forEach((f: ZctaFeature) => {
+        zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+      });
+    }
     await db.transact([db.tx.stats[stat.id].update({ data: JSON.stringify(zctaMap) })]);
   };
 
@@ -42,6 +60,7 @@ export default function StatsPage() {
               <tr>
                 <th className="border px-2 py-1 text-left">Code</th>
                 <th className="border px-2 py-1 text-left">Description</th>
+                <th className="border px-2 py-1 text-left">Formula</th>
                 <th className="border px-2 py-1 text-left">Category</th>
                 <th className="border px-2 py-1 text-left">Dataset</th>
                 <th className="border px-2 py-1 text-left">Source</th>
@@ -54,6 +73,7 @@ export default function StatsPage() {
                 <tr key={stat.id}>
                   <td className="border px-2 py-1">{stat.code}</td>
                   <td className="border px-2 py-1">{stat.description}</td>
+                  <td className="border px-2 py-1">{stat.formula || ''}</td>
                   <td className="border px-2 py-1">{stat.category}</td>
                   <td className="border px-2 py-1">{stat.dataset}</td>
                   <td className="border px-2 py-1">{stat.source}</td>

--- a/components/CensusChat.tsx
+++ b/components/CensusChat.tsx
@@ -14,7 +14,9 @@ interface ChatMessage {
 }
 
 interface CensusChatProps {
-  onAddMetric: (metric: { id: string; label: string }) => void | Promise<void>;
+  onAddMetric: (
+    metric: { id: string; label: string; numerator?: string; denominator?: string }
+  ) => void | Promise<void>;
   onClose?: () => void;
 }
 
@@ -34,7 +36,9 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const lastAssistantRef = useRef<HTMLDivElement | null>(null);
   const runIdRef = useRef(0);
-  const preTurnSnapshotRef = useRef<{ metrics: { id: string; label: string }[]; selected: string | null } | null>(null);
+  const preTurnSnapshotRef = useRef<
+    { metrics: { id: string; label: string; numerator?: string; denominator?: string }[]; selected: string | null } | null
+  >(null);
 
   const CHAT_STORAGE_KEY = 'censusChatMessages';
 
@@ -195,6 +199,13 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
       for (const inv of data.toolInvocations) {
         if (inv.name === 'add_metric') {
           await onAddMetric(inv.args);
+        } else if (inv.name === 'add_percent_metric') {
+          await onAddMetric({
+            id: `${inv.args.numerator}/${inv.args.denominator}`,
+            label: inv.args.label,
+            numerator: inv.args.numerator,
+            denominator: inv.args.denominator,
+          });
         }
       }
     }
@@ -207,7 +218,12 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
 
   const sendMessage = async () => sendMessageWith(input, 'auto');
 
-  const restoreMetricsSnapshot = async (snapshot: { metrics: { id: string; label: string }[]; selected: string | null }) => {
+  const restoreMetricsSnapshot = async (
+    snapshot: {
+      metrics: { id: string; label: string; numerator?: string; denominator?: string }[];
+      selected: string | null;
+    }
+  ) => {
     clearMetrics();
     for (const m of snapshot.metrics) {
       await onAddMetric(m);
@@ -281,6 +297,13 @@ export default function CensusChat({ onAddMetric, onClose }: CensusChatProps) {
       for (const inv of data.toolInvocations) {
         if (inv.name === 'add_metric') {
           await onAddMetric(inv.args);
+        } else if (inv.name === 'add_percent_metric') {
+          await onAddMetric({
+            id: `${inv.args.numerator}/${inv.args.denominator}`,
+            label: inv.args.label,
+            numerator: inv.args.numerator,
+            denominator: inv.args.denominator,
+          });
         }
       }
     }

--- a/components/MetricContext.tsx
+++ b/components/MetricContext.tsx
@@ -10,6 +10,8 @@ import type { Stat } from '../types/stat';
 interface Metric {
   id: string;
   label: string;
+  numerator?: string;
+  denominator?: string;
 }
 
 interface MetricsContextValue {
@@ -18,7 +20,7 @@ interface MetricsContextValue {
   zctaFeatures: ZctaFeature[] | undefined;
   addMetric: (metric: Metric) => Promise<void>;
   loadStatMetric: (stat: Stat) => Promise<void>;
-  selectMetric: (id: string) => Promise<void>;
+  selectMetric: (id: string, metric?: Metric) => Promise<void>;
   clearMetrics: () => void;
 }
 
@@ -44,7 +46,10 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
     // Prefer existing stat from InstantDB if available
     const allStats = (statData?.stats || []) as Stat[];
     const matching = allStats.filter(s => s.code === m.id);
-    const preferred = matching.find(s => s.dataset === config.dataset && String(s.year) === String(config.year)) || matching[0];
+    const preferred =
+      matching.find(
+        s => s.dataset === config.dataset && String(s.year) === String(config.year)
+      ) || matching[0];
     if (preferred) {
       // Log that InstantDB fulfilled this request
       try {
@@ -69,9 +74,57 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
+    if (m.numerator && m.denominator) {
+      const [numFeatures, denFeatures] = await Promise.all([
+        fetchZctaMetric(m.numerator, { year: config.year, dataset: config.dataset }),
+        fetchZctaMetric(m.denominator, { year: config.year, dataset: config.dataset }),
+      ]);
+      const denMap = new Map<string, number | null>();
+      denFeatures.forEach(df => {
+        denMap.set(df.properties.ZCTA5CE10, df.properties.value ?? null);
+      });
+      const features: ZctaFeature[] = numFeatures.map(nf => {
+        const den = denMap.get(nf.properties.ZCTA5CE10);
+        const num = nf.properties.value;
+        const val =
+          num != null && den && den !== 0 ? (num / den) * 100 : null;
+        return { ...nf, properties: { ...nf.properties, value: val } };
+      });
+      const key = `${config.dataset}-${config.year}-${m.id}`;
+      setSelectedMetric(m.id);
+      setMetricFeatures(prev => ({ ...prev, [key]: features }));
+      setZctaFeatures(features);
+
+      const statId = id();
+      const zctaMap: Record<string, number | null> = {};
+      features.forEach(f => {
+        zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+      });
+      try {
+        await db.transact([
+          db.tx.stats[statId].update({
+            code: m.id,
+            description: m.label,
+            category: 'Derived',
+            dataset: config.dataset,
+            source: 'US Census',
+            year: Number(config.year),
+            data: JSON.stringify(zctaMap),
+            formula: `${m.numerator}/${m.denominator}`,
+          }),
+        ]);
+      } catch {
+        // Ignore unique constraint errors if another tab created it
+      }
+      return;
+    }
+
     // Otherwise fetch from US Census and persist
     const varId = m.id.includes('_') ? m.id : m.id + '_001E';
-    const features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
+    const features = await fetchZctaMetric(varId, {
+      year: config.year,
+      dataset: config.dataset,
+    });
     if (features) {
       // Update local selection immediately
       const key = `${config.dataset}-${config.year}-${m.id}`;
@@ -103,7 +156,10 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
   };
 
   const loadStatMetric = async (stat: Stat) => {
-    const m = { id: stat.code, label: stat.description };
+    const [num, den] = stat.formula ? stat.formula.split('/') : [];
+    const m: Metric = num && den
+      ? { id: stat.code, label: stat.description, numerator: num, denominator: den }
+      : { id: stat.code, label: stat.description };
     setMetrics(prev => (prev.find(p => p.id === m.id) ? prev : [...prev, m]));
     const key = `${stat.dataset}-${stat.year}-${m.id}`;
     let features = metricFeatures[key];
@@ -116,17 +172,39 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
     setZctaFeatures(features);
   };
 
-  const selectMetric = async (id: string) => {
-      setSelectedMetric(id);
-      const key = `${config.dataset}-${config.year}-${id}`;
-      let features = metricFeatures[key];
-      if (!features) {
+  const selectMetric = async (id: string, metricArg?: Metric) => {
+    setSelectedMetric(id);
+    const key = `${config.dataset}-${config.year}-${id}`;
+    let features = metricFeatures[key];
+    const m = metricArg || metrics.find(p => p.id === id);
+    if (!features) {
+      if (m?.numerator && m?.denominator) {
+        const [numFeatures, denFeatures] = await Promise.all([
+          fetchZctaMetric(m.numerator, { year: config.year, dataset: config.dataset }),
+          fetchZctaMetric(m.denominator, { year: config.year, dataset: config.dataset }),
+        ]);
+        const denMap = new Map<string, number | null>();
+        denFeatures.forEach(df => {
+          denMap.set(df.properties.ZCTA5CE10, df.properties.value ?? null);
+        });
+        features = numFeatures.map(nf => {
+          const den = denMap.get(nf.properties.ZCTA5CE10);
+          const num = nf.properties.value;
+          const val =
+            num != null && den && den !== 0 ? (num / den) * 100 : null;
+          return { ...nf, properties: { ...nf.properties, value: val } };
+        });
+      } else {
         const varId = id.includes('_') ? id : id + '_001E';
-        features = await fetchZctaMetric(varId, { year: config.year, dataset: config.dataset });
-        setMetricFeatures(prev => ({ ...prev, [key]: features! }));
+        features = await fetchZctaMetric(varId, {
+          year: config.year,
+          dataset: config.dataset,
+        });
       }
-      setZctaFeatures(features);
-    };
+      setMetricFeatures(prev => ({ ...prev, [key]: features! }));
+    }
+    setZctaFeatures(features);
+  };
 
   const clearMetrics = () => {
     setMetrics([]);
@@ -143,7 +221,8 @@ export function MetricsProvider({ children }: { children: React.ReactNode }) {
         if (parsed.metrics) {
           setMetrics(parsed.metrics);
           if (parsed.selected) {
-            selectMetric(parsed.selected);
+            const meta = parsed.metrics.find(m => m.id === parsed.selected);
+            selectMetric(parsed.selected, meta);
           }
         }
       } catch {

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -33,6 +33,7 @@ const _schema = i.schema({
       source: i.string(),
       year: i.number(),
       data: i.string(),
+      formula: i.string().optional(),
     }),
   },
   links: {

--- a/types/stat.ts
+++ b/types/stat.ts
@@ -7,4 +7,5 @@ export interface Stat {
   source: string;
   year: number;
   data: string;
+  formula?: string | null;
 }


### PR DESCRIPTION
## Summary
- allow LLM to create percent metrics via new `add_percent_metric` tool
- compute and persist derived stats, including formulas
- show formula details and refresh logic on Stats page

## Testing
- `npm run lint`
- `npm test` *(fails: Network error: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1cfb189c832dac97ee93c2645fbd