### PR TITLE
feat: support additional census datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,14 @@
 
 ### components/ConfigControls.tsx
 - Dropdown controls for region, year, dataset, geography (provided via `ConfigContext`)
+- Dataset options include ACS 5-year, ACS 1-year, and Decennial PL tables
 
 ## Library Modules
 ### lib/db.ts
 - Instantiates and exports a configured InstantDB client
 
 ### lib/census.ts
-- `fetchZctaMetric` retrieves ACS data for a ZCTA/variable
+- `fetchZctaMetric` retrieves Census data for a ZCTA/variable
 - `prefetchZctaBoundaries` loads and caches GeoJSON polygons
 
 ### lib/censusTools.ts
@@ -170,7 +171,7 @@
 - For metrics: prefer InstantDB stats; otherwise fetch from US Census and persist
 
 ## External Services
-- US Census API for ACS statistics
+- US Census API for ACS and Decennial statistics
 - OpenRouter for LLM responses
 - InstantDB for organization storage
 

--- a/components/ConfigControls.tsx
+++ b/components/ConfigControls.tsx
@@ -3,6 +3,18 @@
 import { useEffect, useState } from 'react';
 import { useConfig } from './ConfigContext';
 
+const DATASET_YEARS: Record<string, string[]> = {
+  'acs/acs5': ['2023', '2022', '2021'],
+  'acs/acs1': ['2023', '2022', '2021'],
+  'dec/pl': ['2020', '2010'],
+};
+
+const DATASET_LABELS: Record<string, string> = {
+  'acs/acs5': 'ACS 5-year',
+  'acs/acs1': 'ACS 1-year',
+  'dec/pl': 'Decennial PL',
+};
+
 export default function ConfigControls() {
   const { config, updateConfig } = useConfig();
   const [notice, setNotice] = useState<string | null>(null);
@@ -20,6 +32,16 @@ export default function ConfigControls() {
     }
   }, [config.dataset, config.geography, updateConfig]);
 
+  // Adjust year when switching datasets with different availability
+  useEffect(() => {
+    const years = DATASET_YEARS[config.dataset] || [];
+    if (!years.includes(config.year)) {
+      updateConfig({ year: years[0] });
+    }
+  }, [config.dataset, config.year, updateConfig]);
+
+  const yearOptions = DATASET_YEARS[config.dataset] || [];
+
   return (
     <div className="grid grid-cols-2 gap-2 mb-2">
       <select
@@ -35,10 +57,11 @@ export default function ConfigControls() {
         value={config.year}
         onChange={(e) => updateConfig({ year: e.target.value })}
       >
-        {['2023', '2022', '2021'].map((y) => {
+        {yearOptions.map((y) => {
           const end = Number(y);
           const start = end - 4;
-          const label = config.dataset === 'acs/acs5' ? `${start}\u2013${end}` : y;
+          const label =
+            config.dataset === 'acs/acs5' ? `${start}\u2013${end}` : y;
           return (
             <option key={y} value={y}>
               {label}
@@ -51,8 +74,11 @@ export default function ConfigControls() {
         value={config.dataset}
         onChange={(e) => updateConfig({ dataset: e.target.value })}
       >
-        <option value="acs/acs5">ACS 5-year</option>
-        <option value="acs/acs1">ACS 1-year</option>
+        {Object.entries(DATASET_LABELS).map(([value, label]) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
       </select>
       <select
         className="border border-gray-300 rounded p-1 text-sm w-full"

--- a/tests/search.test.js
+++ b/tests/search.test.js
@@ -4,6 +4,8 @@ const { searchCensus, validateVariableId } = require('../lib/censusTools');
 
 const YEAR = '2023';
 const DATASET = 'acs/acs5';
+const DEC_YEAR = '2020';
+const DEC_DATASET = 'dec/pl';
 
 test('search median age returns expected variable', async () => {
   const results = await searchCensus('median age', YEAR, DATASET);
@@ -24,6 +26,16 @@ test('validateVariableId checks known and unknown ids', async (t) => {
   try {
     assert.equal(await validateVariableId('B01003_001E', YEAR, DATASET), true);
     assert.equal(await validateVariableId('B99999_999E', YEAR, DATASET), false);
+  } catch (err) {
+    t.diagnostic(`Network error: ${err.message}`);
+    t.skip();
+  }
+});
+
+test('decennial dataset variable is recognized', async (t) => {
+  try {
+    const ok = await validateVariableId('P1_001N', DEC_YEAR, DEC_DATASET);
+    assert.equal(ok, true);
   } catch (err) {
     t.diagnostic(`Network error: ${err.message}`);
     t.skip();


### PR DESCRIPTION
## Summary
- allow selecting Decennial PL dataset alongside ACS 1-year and ACS 5-year
- handle dataset-specific year ranges and compatibility in config controls
- test decennial dataset variable lookup

## Testing
- `npm test` *(fails: Network error: fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c859a88832db7e90108f31fa284