### PR TITLE
feat: support additional Census datasets and geographies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 ## Architecture Overview
 - React contexts manage map configuration and selected metrics
-- MapLibre map overlaid with deck.gl layers for org markers and ZCTA metrics
-- InstantDB stores organization data; US Census API supplies statistics
+- MapLibre map overlaid with deck.gl layers for org markers and metric choropleths
+- InstantDB stores organization data; US Census API supplies statistics from datasets such as ACS 5-year, ACS 1-year, and the Decennial PL census
 - OpenRouter-powered chat searches Census variables and adds layers
 
 ## App Files
@@ -53,8 +53,7 @@
 - Allows editing, deleting, and refreshing stat data
 - Connected to InstantDB stats entity
 
-### app/data/page.tsx
-- Table view of the currently selected metric by ZCTA
+- Table view of the currently selected metric by geography
 - Uses `MetricContext`; shows data when a metric is selected
 
 ### app/about/page.tsx
@@ -69,7 +68,7 @@
 ## Components
 ### components/OKCMap.tsx
 - Composes MapLibre map and deck.gl overlay
-- Builds layers via `createOrganizationLayer` and `createZctaMetricLayer`
+- Builds layers via `createOrganizationLayer` and `createMetricLayer`
 - Emits `onOrganizationClick` callback
 
 ### components/OrganizationDetails.tsx
@@ -86,8 +85,7 @@
 - Appends an Approach chip on assistant messages at the bottom-right of each message row; dropdown to re-run from the last user message with Auto/Fast/Smart
  - Follow-up ideas: after each assistant reply (unless the reply is a question), shows two compact, vertically stacked indigo buttons with next-step ideas — one to "Add data for …?" (avoids active/mentioned metrics) and one curiosity question from the user’s perspective. Clicking runs the relevant action; typing clears them.
 
-### components/MetricContext.tsx
-- React context tracking active ZCTA metrics and geometries
+- React context tracking active metrics and geometries across geographies
 - API: `addMetric`, `selectMetric`, `metrics`, `clearMetrics`
 - Persists active metrics and selected metric to localStorage
 - Prefers InstantDB stats (by code, then dataset/year) before fetching from US Census
@@ -120,8 +118,8 @@
 - Instantiates and exports a configured InstantDB client
 
 ### lib/census.ts
-- `fetchZctaMetric` retrieves ACS data for a ZCTA/variable
-- `prefetchZctaBoundaries` loads and caches GeoJSON polygons
+- `fetchMetric` retrieves Census data for a geography/variable
+- `prefetchZctaBoundaries` and `prefetchCountyBoundaries` load and cache GeoJSON polygons
 
 ### lib/censusTools.ts
 - Loads Census variable metadata and caches results
@@ -130,7 +128,7 @@
 
 ### lib/mapLayers.ts
 - `createOrganizationLayer` for point markers
-- `createZctaMetricLayer` for choropleth metrics
+- `createMetricLayer` for choropleth metrics
 - Pure functions returning deck.gl layers
 
 ### lib/openRouter.ts

--- a/app/data/page.tsx
+++ b/app/data/page.tsx
@@ -2,28 +2,31 @@
 
 import NavBar from '../../components/NavBar';
 import { useMetrics } from '../../components/MetricContext';
+import { useConfig } from '../../components/ConfigContext';
 
 export default function DataPage() {
-  const { metrics, selectedMetric, zctaFeatures } = useMetrics();
+  const { metrics, selectedMetric, features } = useMetrics();
+  const { config } = useConfig();
   const selectedLabel = metrics.find(m => m.id === selectedMetric)?.label;
+  const geoLabel = config.geography === 'county' ? 'County' : 'ZCTA';
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
       <NavBar />
       <main className="flex-1 max-w-4xl mx-auto p-4 w-full overflow-x-auto">
         <p className="text-gray-700 mb-4">add a metric to see on table and map</p>
-        {selectedMetric && zctaFeatures ? (
+        {selectedMetric && features ? (
           <table className="min-w-full text-sm border">
             <thead>
               <tr>
-                <th className="border px-2 py-1 text-left">ZCTA</th>
+                <th className="border px-2 py-1 text-left">{geoLabel}</th>
                 <th className="border px-2 py-1 text-left">{selectedLabel ?? selectedMetric}</th>
               </tr>
             </thead>
             <tbody>
-              {zctaFeatures.map((f) => (
-                <tr key={f.properties.ZCTA5CE10}>
-                  <td className="border px-2 py-1">{f.properties.ZCTA5CE10}</td>
+              {features.map((f) => (
+                <tr key={f.properties.id}>
+                  <td className="border px-2 py-1">{f.properties.name || f.properties.id}</td>
                   <td className="border px-2 py-1">{f.properties.value ?? 'N/A'}</td>
                 </tr>
               ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
-  const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric } = useMetrics();
+  const { metrics, selectedMetric, selectMetric, clearMetrics, features, addMetric } = useMetrics();
 
   // Close Add Organization modal on Escape key
   useEffect(() => {
@@ -76,7 +76,7 @@ export default function Home() {
           <OKCMap
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
-            zctaFeatures={zctaFeatures}
+            features={features}
           />
 
           {/* Overlay metrics glass bar over the map */}

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -2,7 +2,7 @@
 
 import NavBar from '../../components/NavBar';
 import db from '../../lib/db';
-import { fetchZctaMetric, type ZctaFeature } from '../../lib/census';
+import { fetchMetric, type GeoFeature } from '../../lib/census';
 import type { Stat } from '../../types/stat';
 
 export default function StatsPage() {
@@ -21,12 +21,16 @@ export default function StatsPage() {
 
   const handleRefresh = async (stat: Stat) => {
     const varId = stat.code.includes('_') ? stat.code : stat.code + '_001E';
-    const features = await fetchZctaMetric(varId, { year: String(stat.year), dataset: stat.dataset });
-    const zctaMap: Record<string, number | null> = {};
-    features?.forEach((f: ZctaFeature) => {
-      zctaMap[f.properties.ZCTA5CE10] = f.properties.value ?? null;
+    const features = await fetchMetric(varId, {
+      year: String(stat.year),
+      dataset: stat.dataset,
+      geography: (stat.geography || 'zip code tabulation area') as 'zip code tabulation area' | 'county',
     });
-    await db.transact([db.tx.stats[stat.id].update({ data: JSON.stringify(zctaMap) })]);
+    const geoMap: Record<string, number | null> = {};
+    features?.forEach((f: GeoFeature) => {
+      geoMap[f.properties.id] = f.properties.value ?? null;
+    });
+    await db.transact([db.tx.stats[stat.id].update({ data: JSON.stringify(geoMap) })]);
   };
 
   return (
@@ -44,6 +48,7 @@ export default function StatsPage() {
                 <th className="border px-2 py-1 text-left">Description</th>
                 <th className="border px-2 py-1 text-left">Category</th>
                 <th className="border px-2 py-1 text-left">Dataset</th>
+                <th className="border px-2 py-1 text-left">Geography</th>
                 <th className="border px-2 py-1 text-left">Source</th>
                 <th className="border px-2 py-1 text-left">Year</th>
                 <th className="border px-2 py-1 text-left">Actions</th>
@@ -56,6 +61,7 @@ export default function StatsPage() {
                   <td className="border px-2 py-1">{stat.description}</td>
                   <td className="border px-2 py-1">{stat.category}</td>
                   <td className="border px-2 py-1">{stat.dataset}</td>
+                  <td className="border px-2 py-1">{stat.geography}</td>
                   <td className="border px-2 py-1">{stat.source}</td>
                   <td className="border px-2 py-1">{stat.year}</td>
                   <td className="border px-2 py-1 space-x-2">

--- a/instant.schema.ts
+++ b/instant.schema.ts
@@ -30,6 +30,7 @@ const _schema = i.schema({
       description: i.string(),
       category: i.string(),
       dataset: i.string(),
+      geography: i.string(),
       source: i.string(),
       year: i.number(),
       data: i.string(),

--- a/lib/mapLayers.ts
+++ b/lib/mapLayers.ts
@@ -1,7 +1,7 @@
 import { ScatterplotLayer, GeoJsonLayer } from '@deck.gl/layers';
 import type { PickingInfo } from '@deck.gl/core';
 import type { Organization } from '../types/organization';
-import type { ZctaFeature } from './census';
+import type { GeoFeature } from './census';
 
 function getCategoryColor(category: string): [number, number, number, number] {
   // Using design system colors for organization categories
@@ -61,10 +61,10 @@ export function createOrganizationLayer(
   });
 }
 
-export function createZctaMetricLayer(zctaFeatures?: ZctaFeature[]) {
-  if (!zctaFeatures || zctaFeatures.length === 0) return null;
+export function createMetricLayer(features?: GeoFeature[]) {
+  if (!features || features.length === 0) return null;
 
-  const vals = zctaFeatures
+  const vals = features
     .map((f) => f.properties.value)
     .filter((v): v is number => v != null && v >= 0);
   const min = Math.min(...vals);
@@ -92,9 +92,9 @@ export function createZctaMetricLayer(zctaFeatures?: ZctaFeature[]) {
     return [r, g, b, 200];
   };
 
-  return new GeoJsonLayer<ZctaFeature>({
-    id: 'zcta-metric',
-    data: zctaFeatures,
+  return new GeoJsonLayer<GeoFeature>({
+    id: 'metric',
+    data: features,
     stroked: true,
     filled: true,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/types/stat.ts
+++ b/types/stat.ts
@@ -4,6 +4,7 @@ export interface Stat {
   description: string;
   category: string;
   dataset: string;
+  geography: string;
   source: string;
   year: number;
   data: string;


### PR DESCRIPTION
## Summary
- generalize Census fetching to work with ZIP and county geographies
- allow selecting ACS 1-year or Decennial PL datasets with year/geography safeguards
- update map, data table, and stats management to handle new geographies

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c859a88832db7e90108f31fa284