### PR TITLE
feat: add decennial census dataset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - MapLibre map overlaid with deck.gl layers for org markers and ZCTA metrics
 - InstantDB stores organization data; US Census API supplies statistics
 - OpenRouter-powered chat searches Census variables and adds layers
+ - Supports multiple US Census datasets (ACS 1-year/5-year and 2020 Decennial PL)
 
 ## App Files
 ### app/layout.tsx
@@ -120,7 +121,7 @@
 - Instantiates and exports a configured InstantDB client
 
 ### lib/census.ts
-- `fetchZctaMetric` retrieves ACS data for a ZCTA/variable
+- `fetchZctaMetric` retrieves US Census data for a ZCTA/variable across datasets
 - `prefetchZctaBoundaries` loads and caches GeoJSON polygons
 
 ### lib/censusTools.ts
@@ -143,7 +144,7 @@
 - Summarizes `User request` and `InstantDB fulfilled <code>` entries for a readable timeline
 
 ### lib/censusVariables.ts
-- Curated list of ACS variable IDs and descriptions
+- Curated list of Census variable IDs and descriptions from multiple datasets
 - Imported by `censusTools`
 
 ### lib/censusQueryMap.ts
@@ -170,7 +171,7 @@
 - For metrics: prefer InstantDB stats; otherwise fetch from US Census and persist
 
 ## External Services
-- US Census API for ACS statistics
+- US Census API for ACS and Decennial statistics
 - OpenRouter for LLM responses
 - InstantDB for organization storage
 

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -8,6 +8,13 @@ import type { Stat } from '../../types/stat';
 export default function StatsPage() {
   const { data, isLoading, error } = db.useQuery({ stats: {} });
 
+  const datasetLabel = (d: string) => {
+    if (d === 'acs/acs5') return 'ACS 5-year';
+    if (d === 'acs/acs1') return 'ACS 1-year';
+    if (d === 'dec/pl') return 'Decennial 2020 PL';
+    return d;
+    };
+
   const handleEdit = async (stat: Stat) => {
     const desc = prompt('Edit description', stat.description);
     if (desc !== null) {
@@ -55,7 +62,7 @@ export default function StatsPage() {
                   <td className="border px-2 py-1">{stat.code}</td>
                   <td className="border px-2 py-1">{stat.description}</td>
                   <td className="border px-2 py-1">{stat.category}</td>
-                  <td className="border px-2 py-1">{stat.dataset}</td>
+                  <td className="border px-2 py-1">{datasetLabel(stat.dataset)}</td>
                   <td className="border px-2 py-1">{stat.source}</td>
                   <td className="border px-2 py-1">{stat.year}</td>
                   <td className="border px-2 py-1 space-x-2">

--- a/components/ConfigControls.tsx
+++ b/components/ConfigControls.tsx
@@ -7,7 +7,7 @@ export default function ConfigControls() {
   const { config, updateConfig } = useConfig();
   const [notice, setNotice] = useState<string | null>(null);
 
-  // Ensure compatible dataset/geography. ACS 1-year is unavailable for ZCTAs.
+  // Ensure compatible dataset/geography and dataset/year combinations
   useEffect(() => {
     if (
       config.geography === 'zip code tabulation area' &&
@@ -15,10 +15,13 @@ export default function ConfigControls() {
     ) {
       updateConfig({ dataset: 'acs/acs5' });
       setNotice('ACS 1-year is unavailable for ZCTAs. Switched to ACS 5-year.');
+    } else if (config.dataset === 'dec/pl' && config.year !== '2020') {
+      updateConfig({ year: '2020' });
+      setNotice('Decennial PL data is only available for 2020. Year reset to 2020.');
     } else {
       setNotice(null);
     }
-  }, [config.dataset, config.geography, updateConfig]);
+  }, [config.dataset, config.geography, config.year, updateConfig]);
 
   return (
     <div className="grid grid-cols-2 gap-2 mb-2">
@@ -35,10 +38,15 @@ export default function ConfigControls() {
         value={config.year}
         onChange={(e) => updateConfig({ year: e.target.value })}
       >
-        {['2023', '2022', '2021'].map((y) => {
+        {(
+          config.dataset === 'dec/pl'
+            ? ['2020']
+            : ['2023', '2022', '2021']
+        ).map((y) => {
           const end = Number(y);
           const start = end - 4;
-          const label = config.dataset === 'acs/acs5' ? `${start}\u2013${end}` : y;
+          const label =
+            config.dataset === 'acs/acs5' ? `${start}\u2013${end}` : y;
           return (
             <option key={y} value={y}>
               {label}
@@ -53,6 +61,7 @@ export default function ConfigControls() {
       >
         <option value="acs/acs5">ACS 5-year</option>
         <option value="acs/acs1">ACS 1-year</option>
+        <option value="dec/pl">Decennial 2020 PL</option>
       </select>
       <select
         className="border border-gray-300 rounded p-1 text-sm w-full"
@@ -71,6 +80,12 @@ export default function ConfigControls() {
           >
             (what’s this?)
           </span>
+        </div>
+      )}
+
+      {config.dataset === 'dec/pl' && (
+        <div className="col-span-2 text-xs text-gray-600">
+          Using 2020 Decennial Census P.L. counts
         </div>
       )}
 

--- a/lib/censusVariables.ts
+++ b/lib/censusVariables.ts
@@ -36,4 +36,16 @@ export const CURATED_VARIABLES: CensusVariableInfo[] = [
     concept: 'Hispanic or Latino Origin',
     keywords: ['hispanic', 'latino'],
   },
+  {
+    id: 'P1_001N',
+    label: 'Total Population (Decennial)',
+    concept: 'P1: RACE -- Total population',
+    keywords: ['population', 'people', 'total', 'decennial'],
+  },
+  {
+    id: 'H1_001N',
+    label: 'Total Housing Units',
+    concept: 'H1: OCCUPANCY STATUS -- Housing units',
+    keywords: ['housing', 'units', 'total', 'decennial'],
+  },
 ];


### PR DESCRIPTION
## Summary
- allow choosing 2020 Decennial PL data in config controls
- include decennial variables and dataset-aware search logic
- show friendly dataset names in stats table and docs

## Testing
- `npm run lint`
- `npm test` (fails: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_68ae1c859a88832db7e90108f31fa284