### PR TITLE
Highlight AI-suggested ZIPs on map

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -74,6 +74,24 @@ async function runModel(
         },
       },
     },
+    {
+      type: 'function',
+      function: {
+        name: 'highlight_zips',
+        description: 'Highlight the given ZIP or ZCTA codes on the map.',
+        parameters: {
+          type: 'object',
+          properties: {
+            zips: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'List of 5-digit ZIP codes',
+            },
+          },
+          required: ['zips'],
+        },
+      },
+    },
   ];
 
   const toolInvocations: { name: string; args: Record<string, unknown> }[] = [];
@@ -132,6 +150,13 @@ async function runModel(
         } else {
           result = { ok: false, error: 'Unknown variable id' };
         }
+      } else if (name === 'highlight_zips') {
+        const zArg = Array.isArray(args.zips)
+          ? (args.zips as unknown[])
+          : [];
+        const zips = zArg.filter((z): z is string => typeof z === 'string');
+        result = { ok: true };
+        toolInvocations.push({ name, args: { zips } });
       }
       convo.push({
         role: 'tool',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ export default function Home() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
+  const [highlightZips, setHighlightZips] = useState<string[]>([]);
   const { metrics, selectedMetric, selectMetric, clearMetrics, zctaFeatures, addMetric } = useMetrics();
 
   // Close Add Organization modal on Escape key
@@ -77,6 +78,7 @@ export default function Home() {
             organizations={organizations}
             onOrganizationClick={setSelectedOrg}
             zctaFeatures={zctaFeatures}
+            highlightedZips={highlightZips}
           />
 
           {/* Overlay metrics glass bar over the map */}
@@ -142,7 +144,7 @@ export default function Home() {
 
       {!isChatCollapsed ? (
         <div className="fixed bottom-4 right-4 w-[30rem] h-[38.4rem] bg-white text-gray-900 shadow-lg p-2 border rounded-lg">
-          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} />
+          <CensusChat onAddMetric={addMetric} onClose={() => setIsChatCollapsed(true)} onHighlightZips={setHighlightZips} />
         </div>
       ) : (
         <button

--- a/components/OKCMap.tsx
+++ b/components/OKCMap.tsx
@@ -1,18 +1,20 @@
 'use client';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import Map from 'react-map-gl/maplibre';
 import DeckGL from '@deck.gl/react';
 import type { Organization } from '../types/organization';
 
-import type { ZctaFeature } from '../lib/census';
-import { createOrganizationLayer, createZctaMetricLayer } from '../lib/mapLayers';
+import { createOrganizationLayer, createZctaMetricLayer, createZctaHighlightLayer } from '../lib/mapLayers';
+import { featuresFromZctaMap, type ZctaFeature } from '../lib/census';
+import { WebMercatorViewport } from '@deck.gl/core';
 
 interface OKCMapProps {
   organizations: Organization[];
   onOrganizationClick?: (org: Organization) => void;
   zctaFeatures?: ZctaFeature[];
+  highlightedZips?: string[];
 }
 
 const OKC_CENTER = {
@@ -20,7 +22,7 @@ const OKC_CENTER = {
   latitude: 35.4676
 };
 
-export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures }: OKCMapProps) {
+export default function OKCMap({ organizations, onOrganizationClick, zctaFeatures, highlightedZips }: OKCMapProps) {
   const [viewState, setViewState] = useState({
     longitude: OKC_CENTER.longitude,
     latitude: OKC_CENTER.latitude,
@@ -28,6 +30,66 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
     pitch: 0,
     bearing: 0
   });
+  const [highlightFeatures, setHighlightFeatures] = useState<ZctaFeature[] | undefined>();
+
+  useEffect(() => {
+    const load = async () => {
+      if (!highlightedZips || highlightedZips.length === 0) {
+        setHighlightFeatures(undefined);
+        return;
+      }
+      const map: Record<string, null> = {};
+      highlightedZips.forEach((z) => {
+        map[z] = null;
+      });
+      const feats = await featuresFromZctaMap(map);
+      setHighlightFeatures(feats);
+
+      const bounds = feats.reduce(
+        (acc, f) => {
+          const coords = (f.geometry as any).coordinates;
+          const flat = (function flatten(c: any): number[][] {
+            if (typeof c[0] === 'number') return [c as number[]];
+            return c.flatMap(flatten);
+          })(coords);
+          flat.forEach(([lng, lat]) => {
+            acc[0] = Math.min(acc[0], lng);
+            acc[1] = Math.min(acc[1], lat);
+            acc[2] = Math.max(acc[2], lng);
+            acc[3] = Math.max(acc[3], lat);
+          });
+          return acc;
+        },
+        [Infinity, Infinity, -Infinity, -Infinity] as [number, number, number, number]
+      );
+
+      if (bounds[0] !== Infinity) {
+        const viewport = new WebMercatorViewport({
+          width: window.innerWidth,
+          height: window.innerHeight,
+          longitude: viewState.longitude,
+          latitude: viewState.latitude,
+          zoom: viewState.zoom,
+        });
+        const fitted = viewport.fitBounds(
+          [ [bounds[0], bounds[1]], [bounds[2], bounds[3]] ],
+          { padding: 40, maxZoom: viewState.zoom }
+        );
+        const vp2 = new WebMercatorViewport({
+          width: window.innerWidth,
+          height: window.innerHeight,
+          longitude: fitted.longitude,
+          latitude: fitted.latitude,
+          zoom: fitted.zoom,
+        });
+        const [x, y] = vp2.project([fitted.longitude, fitted.latitude]);
+        const [lng, lat] = vp2.unproject([x + window.innerWidth * 0.3, y]);
+        setViewState((v) => ({ ...v, longitude: lng, latitude: lat, zoom: fitted.zoom }));
+      }
+    };
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightedZips]);
 
   const layers = useMemo(() => {
     const layers: any[] = [createOrganizationLayer(organizations, onOrganizationClick)];
@@ -35,8 +97,12 @@ export default function OKCMap({ organizations, onOrganizationClick, zctaFeature
     if (zctaLayer) {
       layers.unshift(zctaLayer);
     }
+    const highlightLayer = createZctaHighlightLayer(highlightFeatures);
+    if (highlightLayer) {
+      layers.push(highlightLayer);
+    }
     return layers;
-  }, [organizations, onOrganizationClick, zctaFeatures]);
+  }, [organizations, onOrganizationClick, zctaFeatures, highlightFeatures]);
 
   return (
     <div className="w-full h-full relative">

--- a/lib/mapLayers.ts
+++ b/lib/mapLayers.ts
@@ -104,3 +104,21 @@ export function createZctaMetricLayer(zctaFeatures?: ZctaFeature[]) {
     pickable: true,
   });
 }
+
+export function createZctaHighlightLayer(zctaFeatures?: ZctaFeature[]) {
+  if (!zctaFeatures || zctaFeatures.length === 0) return null;
+
+  return new GeoJsonLayer<ZctaFeature>({
+    id: 'zcta-highlight',
+    data: zctaFeatures,
+    stroked: true,
+    filled: false,
+    getLineColor: [215, 168, 0, 255],
+    lineWidthUnits: 'pixels',
+    lineWidthMinPixels: 4,
+    // depthTest isn't in deck.gl's type defs but we want the outlines above other layers
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parameters: { depthTest: false } as any,
+    pickable: false,
+  });
+}


### PR DESCRIPTION
## Summary
- expose `highlight_zips` function so the model can decide which ZIPs to outline
- listen for `highlight_zips` calls in chat and clear highlights when absent
- offset map recentering to the left to compensate for the chat panel

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae17ca3b28832d9b7ca3e22c9df3ca